### PR TITLE
Type aware scratch buffer initialization

### DIFF
--- a/src/AeroMapping.jl
+++ b/src/AeroMapping.jl
@@ -74,12 +74,14 @@ function mapACDMS(t,azi_j,mesh,el,advanceTurb;numAeroTS = 1,alwaysrecalc=true,ou
     Nslices = length(Rp[1,:,1])
 
     # Initialize bladeForces
-    N = zeros(NBlade,numAeroTS,Nslices)
-    T = zeros(NBlade,numAeroTS,Nslices)
-    X = zeros(NBlade,numAeroTS,Nslices)
-    Y = zeros(NBlade,numAeroTS,Nslices)
-    Z = zeros(NBlade,numAeroTS,Nslices)
-    M25 = zeros(NBlade,numAeroTS,Nslices)
+    # TODO: This should be `eltype(Rp)` or similar but currently that return `Real` instead of a concrete type
+    TT = typeof(first(Rp))
+    N = zeros(TT, NBlade, numAeroTS, Nslices)
+    T = zeros(TT, NBlade, numAeroTS, Nslices)
+    X = zeros(TT, NBlade, numAeroTS, Nslices)
+    Y = zeros(TT, NBlade, numAeroTS, Nslices)
+    Z = zeros(TT, NBlade, numAeroTS, Nslices)
+    M25 = zeros(TT, NBlade, numAeroTS, Nslices)
 
     for iTS=1:numAeroTS
         if numAeroTS == 1
@@ -110,12 +112,12 @@ function mapACDMS(t,azi_j,mesh,el,advanceTurb;numAeroTS = 1,alwaysrecalc=true,ou
     structuralElNumbers = mesh.structuralElNumbers
 
     #Initialize structuralLoad
-    struct_N = zeros(NBlade,numAeroTS,length(structuralElNumbers[1,:]))
-    struct_T = zeros(NBlade,numAeroTS,length(structuralElNumbers[1,:]))
-    struct_M25 = zeros(NBlade,numAeroTS,length(structuralElNumbers[1,:]))
-    struct_X = zeros(NBlade,numAeroTS,length(structuralElNumbers[1,:]))
-    struct_Y = zeros(NBlade,numAeroTS,length(structuralElNumbers[1,:]))
-    struct_Z = zeros(NBlade,numAeroTS,length(structuralElNumbers[1,:]))
+    struct_N = zeros(TT, NBlade, numAeroTS, length(structuralElNumbers[1, :]))
+    struct_T = zeros(TT, NBlade, numAeroTS, length(structuralElNumbers[1, :]))
+    struct_M25 = zeros(TT, NBlade, numAeroTS, length(structuralElNumbers[1, :]))
+    struct_X = zeros(TT, NBlade, numAeroTS, length(structuralElNumbers[1, :]))
+    struct_Y = zeros(TT, NBlade, numAeroTS, length(structuralElNumbers[1, :]))
+    struct_Z = zeros(TT, NBlade, numAeroTS, length(structuralElNumbers[1, :]))
     if maximum(structuralSpanLocNorm)>1.0 || minimum(structuralSpanLocNorm)<0.0
         @warn "extrapolating on akima spline, unexpected behavior may occur (very large numbers)."
     end
@@ -138,8 +140,8 @@ function mapACDMS(t,azi_j,mesh,el,advanceTurb;numAeroTS = 1,alwaysrecalc=true,ou
     #read element aero_data in
     numDOFPerNode = 6
     #     [~,~,timeLen] = size(aeroDistLoadsArrayTime)
-    Fg = zeros(Int(mesh.numNodes*6),numAeroTS)
-    Fg_global = zeros(Int(mesh.numNodes*6),numAeroTS)
+    Fg = zeros(TT, mesh.numNodes * 6, numAeroTS)
+    Fg_global = zeros(TT, mesh.numNodes * 6, numAeroTS)
     for i=1:numAeroTS
         for j = 1:NBlade
             for k = 1:numNodesPerBlade-1
@@ -184,8 +186,8 @@ function mapACDMS(t,azi_j,mesh,el,advanceTurb;numAeroTS = 1,alwaysrecalc=true,ou
     #history
     # ForceValHist = zeros(sum(Fg[:,1].!=0),length(Fg[1,:]))
     # ForceDof = zeros(sum(Fg[:,1].!=0),1)
-    ForceValHist = zeros(length(Fg[:,1]),length(Fg[1,:]))
-    ForceDof = zeros(Int,length(Fg[:,1]),1)
+    ForceValHist = zeros(TT, size(Fg))
+    ForceDof = zeros(Int, size(Fg, 1))
     index = 1
     for i=1:Int(mesh.numNodes*6)
         # if !isempty(findall(x->x!=0,Fg[i,:]))

--- a/src/Unsteady.jl
+++ b/src/Unsteady.jl
@@ -879,7 +879,7 @@ function structuralDynamicsTransientGX(topModel,mesh,Fexternal,ForceDof,system,a
     return (strainGX,curvGX), dispOut, FReaction_j,systemout
 end
 
-function run_aero_with_deform(aero,deformAero,mesh,el,u_j,uddot_j,inputs,numIterations,t_i,azi_j,Omega_j,gravityOn)
+function run_aero_with_deform(aero,deformAero,mesh,el,u_j::AbstractVector{T},uddot_j::AbstractVector{T},inputs,numIterations,t_i,azi_j,Omega_j,gravityOn) where {T}
 
     if inputs.tocp_Vinf == -1
         newVinf = -1
@@ -891,8 +891,8 @@ function run_aero_with_deform(aero,deformAero,mesh,el,u_j,uddot_j,inputs,numIter
         # Transform Global Displacements to Local
         numDOFPerNode = 6
 
-        u_j_local = zeros(Int(max(maximum(mesh.structuralNodeNumbers))*6))
-        uddot_j_local = zeros(Int(max(maximum(mesh.structuralNodeNumbers))*6))
+        u_j_local = zeros(T, Int(maximum(mesh.structuralNodeNumbers)) * 6)
+        uddot_j_local = zeros(T, Int(maximum(mesh.structuralNodeNumbers)) * 6)
         for jbld = 1:length(mesh.structuralElNumbers[:,1])
             for kel = 1:length(mesh.structuralElNumbers[1,:])-1
                 # orientation angle,xloc,sectionProps,element order]
@@ -933,12 +933,13 @@ function run_aero_with_deform(aero,deformAero,mesh,el,u_j,uddot_j,inputs,numIter
         # disp_twist2 = [u_j_local[i] for i = 5:6:length(u_j_local)]
         # disp_twist3 = [u_j_local[i] for i = 6:6:length(u_j_local)]
 
-        bld_x = copy(mesh.structuralNodeNumbers[:,1:end-1]).*0.0
-        bld_y = copy(mesh.structuralNodeNumbers[:,1:end-1]).*0.0
-        bld_z = copy(mesh.structuralNodeNumbers[:,1:end-1]).*0.0
-        bld_twist = copy(mesh.structuralNodeNumbers[:,1:end-1]).*0.0
-        accel_flap_in = copy(mesh.structuralNodeNumbers[:,1:end-1]).*0.0
-        accel_edge_in = copy(mesh.structuralNodeNumbers[:,1:end-1]).*0.0
+        sz = (size(mesh.structuralNodeNumbers, 1), size(mesh.structuralNodeNumbers, 2) - 1)
+        bld_x = zeros(T, sz)
+        bld_y = zeros(T, sz)
+        bld_z = zeros(T, sz)
+        bld_twist = zeros(T, sz)
+        accel_flap_in = zeros(T, sz)
+        accel_edge_in = zeros(T, sz)
 
         for jbld = 1:length(mesh.structuralNodeNumbers[:,1])
             bld_indices = Int.(mesh.structuralNodeNumbers[jbld,1:end-1])

--- a/src/Unsteady_Land.jl
+++ b/src/Unsteady_Land.jl
@@ -444,7 +444,7 @@ function Unsteady_Land(inputs;topModel=nothing,topMesh=nothing,topEl=nothing,
                     else
                         if length(size(aeroVals))==1 || size(aeroVals)[2]==1 #i.e. the standard aero force input as a long array
                             # Fill in forces and dofs if they were specified not in full arrays TODO: make this more efficient
-                            full_aeroVals = zeros(topMesh.numNodes*6)
+                            full_aeroVals = zeros(eltype(aeroVals), topMesh.numNodes * 6)
                             for i_idx = 1:length(aeroDOFs)
                                 full_aeroVals[Int(aeroDOFs[i_idx])] = aeroVals[i_idx]
                             end

--- a/src/meshing_utilities.jl
+++ b/src/meshing_utilities.jl
@@ -1005,7 +1005,7 @@ function calculateElementOrientation2(mesh)
     twist_d2=zeros(numEl)
     Offset=zeros(3,numEl)    #offset is the hub frame coordinate of node 1 of the element
     vsave=zeros(numEl,3)    #offset is the hub frame coordinate of node 1 of the element
-    elNum=zeros(numEl,2) #initialize element number array
+    elNum = zeros(Int, numEl, 2) #initialize element number array
 
 
     #calculate "mesh centroid"


### PR DESCRIPTION
This patch changes how some local scratch buffers are initialized so that the input type is taken into account to support e.g. dual numbers. Initialization is now done by calling `zeros` directly which save some allocations (the old code allocated once for the call to getindex ([...]), once in `copy` and finally once in the multiplication with 0). Extracted from #100.