### PR TITLE
Use Vref for DLC extreme winds

### DIFF
--- a/src/preprocessing/setup_utilities.jl
+++ b/src/preprocessing/setup_utilities.jl
@@ -112,13 +112,13 @@ mutable struct TowerSetupOptions
     strut_tower_joint_type::Int
 
     function TowerSetupOptions(;
-        Htwr_base::Float64 = 2.0,           
-        Htwr_blds::Float64 = 5.0,           
-        strut_twr_mountpoint::Vector{Float64} = [0.25, 0.75],  
-        strut_bld_mountpoint::Vector{Float64} = [0.25, 0.75],  
-        joint_type::Int = 2,             
-        c_mount_ratio::Float64 = 0.05,          
-        angularOffset::Float64 = -pi/2,         
+        Htwr_base::Float64 = 2.0,
+        Htwr_blds::Float64 = 5.0,
+        strut_twr_mountpoint::Vector{Float64} = [0.25, 0.75],
+        strut_bld_mountpoint::Vector{Float64} = [0.25, 0.75],
+        joint_type::Int = 2,
+        c_mount_ratio::Float64 = 0.05,
+        angularOffset::Float64 = -pi/2,
         NuMad_geom_xlscsv_file_twr::Any = nothing,
         NuMad_mat_xlscsv_file_twr::Any = nothing,
         NuMad_geom_xlscsv_file_strut::Any = nothing,
@@ -189,12 +189,14 @@ mutable struct BladeSetupOptions
     blade_joint_angle_Degrees::Float64
 
     function BladeSetupOptions(;
-        B::Int = 3,  
-        H::Float64 = 5.0,  
-        R::Float64 = 2.5,  
-        shapeZ::Vector{Float64} = collect(LinRange(0, 5.0, 31)),  
-        shapeX::Vector{Float64} = 2.5 .* (1.0 .- 4.0 .* (collect(LinRange(0, 5.0, 31))/5.0 .- 0.5) .^ 2),  
-        shapeY::Vector{Float64} = zeros(31),  
+        B::Int = 3,
+        H::Float64 = 5.0,
+        R::Float64 = 2.5,
+        shapeZ::Vector{Float64} = collect(LinRange(0, 5.0, 31)),
+        shapeX::Vector{Float64} = 2.5 .* (
+            1.0 .- 4.0 .* (collect(LinRange(0, 5.0, 31))/5.0 .- 0.5) .^ 2
+        ),
+        shapeY::Vector{Float64} = zeros(31),
         NuMad_geom_xlscsv_file_bld::Any = nothing,
         NuMad_mat_xlscsv_file_bld::Any = nothing,
         strut_blade_joint_type::Int = 0,
@@ -381,7 +383,7 @@ mutable struct AeroSetupOptions
             AD15On,
         )
     end
-  
+
     function AeroSetupOptions(dict::OrderedDict{Symbol,Any})
         new(
             get(dict, :rho, 1.225),

--- a/src/runtime/DLCAnalysis.jl
+++ b/src/runtime/DLCAnalysis.jl
@@ -2,7 +2,13 @@ using OrderedCollections: OrderedDict
 using YAML
 
 export DLC_internal,
-    runDLC, getDLCparams, generateUniformwind, generateTurbsimBTS, getGustVel, simpleGustVel
+    runDLC,
+    getDLCparams,
+    generateUniformwind,
+    generateTurbsimBTS,
+    getGustVel,
+    simpleGustVel,
+    iecExtremeWindSpeeds
 
 """
     DLC_internal
@@ -68,6 +74,29 @@ mutable struct DLC_internal
     LinVertShear::Any
     gustvel::Any
     UpflowAngle::Any
+end
+
+"""
+    iecExtremeWindSpeeds(Vref; ve50_factor=1.4, ve1_factor=0.8)
+
+Return the hub-height extreme-wind speeds used by the DLC generator for IEC
+61400-1 parked and idling cases.
+
+`Vref` is the class/reference wind speed already supplied through
+`DLC_Options.Vref`.  The current DLC generator does not evaluate the full IEC
+vertical profile here; it passes hub-height `URef` values to TurbSim or the
+deterministic wind writer.  The defaults therefore expose the IEC factors used
+by the DLC selector explicitly: `Ve50 = 1.4Vref` and `Ve1 = 0.8Ve50`.
+"""
+function iecExtremeWindSpeeds(Vref; ve50_factor = 1.4, ve1_factor = 0.8)
+    all(isfinite, (Vref, ve50_factor, ve1_factor)) ||
+        throw(ArgumentError("Vref and extreme-wind factors must be finite"))
+    Vref > 0 || throw(ArgumentError("Vref must be positive"))
+    ve50_factor > 0 || throw(ArgumentError("ve50_factor must be positive"))
+    ve1_factor > 0 || throw(ArgumentError("ve1_factor must be positive"))
+
+    Ve50 = Vref * ve50_factor
+    return (Ve50 = Ve50, Ve1 = Ve50 * ve1_factor)
 end
 
 """
@@ -203,8 +232,9 @@ function getDLCparams(
 
     Htwr_base = hub_height-Blade_Height/2
 
-    Ve50 = 50.0 #TODO change by class etc
-    Ve1 = 30.0 #TODO
+    extreme_wind_speeds = iecExtremeWindSpeeds(Vref)
+    Ve50 = extreme_wind_speeds.Ve50
+    Ve1 = extreme_wind_speeds.Ve1
 
     numTS = modelopt.OWENS_Options.numTS
     delta_t = modelopt.OWENS_Options.delta_t

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 path = splitdir(@__FILE__)[1]
 using Test
 
+@testset "DLC Parameter Helpers" begin
+    include("$path/test_dlc.jl")
+end
+
 @testset "SNL5MW With CACTUS One-Way Coupling, Preprepared Input Files" begin
     include("$path/SNL5MW_CACT_oneway_unit.jl")
 end

--- a/test/test_dlc.jl
+++ b/test/test_dlc.jl
@@ -1,0 +1,118 @@
+using Test
+import OWENS
+
+function minimal_dlc_model_options()
+    return (
+        OWENS_Options = (numTS = 200, delta_t = 0.1),
+        Mesh_Options = (ntelem = 4, nbelem = 5),
+    )
+end
+
+function minimal_dlc_design_parameters()
+    return Dict(
+        :assembly => Dict(:hub_height => 30.0),
+        :components => Dict(
+            :blade => Dict(
+                :outer_shape_bem => Dict(
+                    :reference_axis => Dict(
+                        :x => Dict(:values => [2.0, 3.0, 5.0]),
+                        :y => Dict(:values => [0.0, 4.0, 0.0]),
+                        :z => Dict(:values => [0.0, 10.0, 20.0]),
+                    ),
+                ),
+            ),
+        ),
+    )
+end
+
+function dlc_params(case; Vref = 42.0, Vinf_range = [5.0, 10.0, 15.0])
+    return OWENS.getDLCparams(
+        case,
+        minimal_dlc_model_options(),
+        minimal_dlc_design_parameters(),
+        Vinf_range,
+        11.0,
+        Vref,
+        "\"A\"",
+        1,
+        "\"1-ED3\"";
+        grid_oversize = 1.1,
+        simtime_turbsim = nothing,
+        delta_t_turbsim = nothing,
+        NumGrid_Z = nothing,
+        NumGrid_Y = nothing,
+        RandSeed1 = 40071,
+    )
+end
+
+@testset "IEC extreme wind speeds from Vref" begin
+    speeds = OWENS.iecExtremeWindSpeeds(42.0)
+
+    @test speeds isa NamedTuple{(:Ve50, :Ve1),Tuple{Float64,Float64}}
+    @test speeds.Ve50 == 58.8
+    @test speeds.Ve1 == 47.04
+
+    custom_speeds = OWENS.iecExtremeWindSpeeds(10.0; ve50_factor = 1.2, ve1_factor = 0.75)
+    @test custom_speeds isa NamedTuple{(:Ve50, :Ve1),Tuple{Float64,Float64}}
+    @test custom_speeds.Ve50 == 12.0
+    @test custom_speeds.Ve1 == 9.0
+
+    @test_throws ArgumentError OWENS.iecExtremeWindSpeeds(0.0)
+    @test_throws ArgumentError OWENS.iecExtremeWindSpeeds(-1.0)
+    @test_throws ArgumentError OWENS.iecExtremeWindSpeeds(Inf)
+    @test_throws ArgumentError OWENS.iecExtremeWindSpeeds(10.0; ve50_factor = 0.0)
+    @test_throws ArgumentError OWENS.iecExtremeWindSpeeds(10.0; ve1_factor = -0.5)
+end
+
+@testset "DLC parked extreme winds use Vref" begin
+    dlc_6_1 = dlc_params("6_1")
+    @test dlc_6_1.Vinf_range_used isa Vector{Float64}
+    @test dlc_6_1.Vinf_range_used == [58.8]
+    @test dlc_6_1.analysis_type == "U"
+    @test dlc_6_1.controlStrategy == "parked"
+    @test dlc_6_1.IEC_WindType == "\"1EWM50\""
+    @test dlc_6_1.GridHeight == 22.0
+    @test dlc_6_1.GridWidth == 11.0
+    @test dlc_6_1.HubHt == 30.0
+    @test dlc_6_1.TimeStep == 0.1
+    @test dlc_6_1.AnalysisTime == 20.0
+
+    dlc_6_2 = dlc_params("6_2")
+    @test dlc_6_2.Vinf_range_used isa Vector{Float64}
+    @test dlc_6_2.Vinf_range_used == [58.8]
+    @test dlc_6_2.analysis_type == "U"
+    @test dlc_6_2.controlStrategy == "parked_idle"
+    @test dlc_6_2.IEC_WindType == "\"1EWM50\""
+
+    dlc_6_3 = dlc_params("6_3")
+    @test dlc_6_3.Vinf_range_used isa Vector{Float64}
+    @test dlc_6_3.Vinf_range_used == [47.04]
+    @test dlc_6_3.analysis_type == "U"
+    @test dlc_6_3.controlStrategy == "parked_yaw"
+    @test dlc_6_3.IEC_WindType == "\"1EWM1\""
+
+    dlc_6_4 = dlc_params("6_4")
+    @test dlc_6_4.Vinf_range_used isa Vector{Float64}
+    @test dlc_6_4.Vinf_range_used == [41.16]
+    @test dlc_6_4.analysis_type == "F"
+    @test dlc_6_4.controlStrategy == "parked"
+    @test dlc_6_4.IEC_WindType == "\"1NTM\""
+
+    dlc_7_1 = dlc_params("7_1")
+    @test dlc_7_1.Vinf_range_used isa Vector{Float64}
+    @test dlc_7_1.Vinf_range_used == [47.04]
+    @test dlc_7_1.analysis_type == "U"
+    @test dlc_7_1.controlStrategy == "parked"
+    @test dlc_7_1.IEC_WindType == "\"1EWM1\""
+end
+
+@testset "DLC normal-operation wind range remains explicit" begin
+    requested_range = [4.0, 8.0, 12.0]
+    dlc_1_1 = dlc_params("1_1"; Vref = 99.0, Vinf_range = requested_range)
+
+    @test dlc_1_1.Vinf_range_used === requested_range
+    @test dlc_1_1.Vinf_range_used isa Vector{Float64}
+    @test dlc_1_1.analysis_type == "UF"
+    @test dlc_1_1.controlStrategy == "normal"
+    @test dlc_1_1.IEC_WindType == "\"1NTM\""
+end


### PR DESCRIPTION
## Summary
- replace hard-coded DLC extreme wind speeds with IEC factors derived from DLC_Options.Vref
- export/document iecExtremeWindSpeeds for the DLC selector
- add pinned unit tests for IEC 6.x/7.1 parked/idling winds and normal-operation range preservation

## Tests
- julia --project=. test/test_dlc.jl
- julia --project=. -e 'using JuliaFormatter; format("src/runtime/DLCAnalysis.jl", verbose=true)'
- git diff --check

References #49.