### PR TITLE
Pin TurbSim DLC template rendering

### DIFF
--- a/src/runtime/DLCAnalysis.jl
+++ b/src/runtime/DLCAnalysis.jl
@@ -6,6 +6,7 @@ export DLC_internal,
     getDLCparams,
     generateUniformwind,
     generateTurbsimBTS,
+    renderTurbsimInputLines,
     getGustVel,
     simpleGustVel,
     iecExtremeWindSpeeds
@@ -74,6 +75,53 @@ mutable struct DLC_internal
     LinVertShear::Any
     gustvel::Any
     UpflowAngle::Any
+end
+
+const TURBSIM_DLC_EXCLUDED_FIELDS = (
+    :Vinf_range_used,
+    :analysis_type,
+    :controlStrategy,
+    :time,
+    :windvel,
+    :winddir,
+    :windvertvel,
+    :horizshear,
+    :pwrLawVertShear,
+    :LinVertShear,
+    :gustvel,
+    :UpflowAngle,
+)
+
+"""
+    renderTurbsimInputLines(lines, DLCParams)
+
+Return a rendered copy of a TurbSim input template using scalar values from
+`DLCParams`.
+
+TurbSim template lines are matched by exact descriptor keys in the second
+whitespace-separated column before the ` - ` comment separator.  Time-series
+and OWENS-only DLC fields are intentionally skipped because they do not map to
+scalar TurbSim input keys.
+"""
+function renderTurbsimInputLines(lines, DLCParams)
+    turbsim_values = Dict{String,Any}()
+    for fieldname in fieldnames(typeof(DLCParams))
+        fieldname in TURBSIM_DLC_EXCLUDED_FIELDS && continue
+        turbsim_values[String(fieldname)] = getfield(DLCParams, fieldname)
+    end
+
+    return map(lines) do line
+        split_line = split(line, " - "; limit = 2)
+        length(split_line) == 2 || return line
+
+        value_and_key = split(strip(split_line[1]))
+        length(value_and_key) >= 2 || return line
+
+        key = value_and_key[2]
+        haskey(turbsim_values, key) || return line
+
+        return "$(turbsim_values[key]) $key - $(split_line[2])"
+    end
 end
 
 """
@@ -715,27 +763,7 @@ function generateTurbsimBTS(
     templatefile = "$module_path/template_files/templateTurbSim.inp",
 )
 
-    lines = readlines(templatefile)
-
-    for fieldname in fieldnames(typeof(DLCParams))
-        turbsimKeyName = String(fieldname)
-        myvalue = getfield(DLCParams, fieldname)
-        if turbsimKeyName != "Vinf_range_used" ||
-           turbsimKeyName != "analysis_type" ||
-           turbsimKeyName != "ControlStrategy"# || other strings
-            for (iline, line) in enumerate(lines)
-                if contains(line, " - ") #TODO: this assumes that the keys aren't in the comments
-                    linenocomments, comments = split(line, " - ")
-                    if contains(linenocomments, turbsimKeyName)
-                        value, descriptor = split(linenocomments)
-                        newline = "$myvalue $turbsimKeyName - $comments"
-                        lines[iline] = newline
-                        break
-                    end
-                end
-            end
-        end
-    end
+    lines = renderTurbsimInputLines(readlines(templatefile), DLCParams)
 
     # Write the new file
     open(windINPfilename, "w") do file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,10 @@ using Test
     include("$path/test_dlc.jl")
 end
 
+@testset "TurbSim Template Rendering" begin
+    include("$path/test_turbsim_template.jl")
+end
+
 @testset "SNL5MW With CACTUS One-Way Coupling, Preprepared Input Files" begin
     include("$path/SNL5MW_CACT_oneway_unit.jl")
 end

--- a/test/test_turbsim_template.jl
+++ b/test/test_turbsim_template.jl
@@ -1,0 +1,74 @@
+using Test
+import OWENS
+
+function sample_dlc_internal()
+    return OWENS.DLC_internal(
+        [12.5],
+        "U",
+        "parked",
+        12345,
+        17,
+        19,
+        0.25,
+        75.0,
+        60.0,
+        110.0,
+        120.0,
+        1.5,
+        -2.5,
+        "\"IECKAI\"",
+        "\"1-ED3\"",
+        "\"B\"",
+        "\"1EWM50\"",
+        75.0,
+        12.5,
+        [0.0, 1.0],
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+    )
+end
+
+@testset "TurbSim template renderer" begin
+    template_lines = [
+        "False     Echo        - Echo input data to <RootName>.ech (flag)",
+        "40071     RandSeed1   - First random seed (-2147483648 to 2147483647)",
+        "30        NumGrid_Z   - Vertical grid-point matrix dimension",
+        "0.05      TimeStep    - Time step [s]",
+        "58.0      HubHt       - Hub height [m] (should be > 0.5*GridHeight)",
+        "0         VFlowAng    - Vertical mean flow (uptilt) angle [degrees]",
+        "\"A\"       IECturbc    - IEC turbulence characteristic",
+        "\"1ETM\"    IEC_WindType - IEC turbulence type",
+        "5.0       URef        - Mean wind speed at the reference height [m/s]",
+        "placeholder URefExtra - Similar name that must not match URef",
+        "normal    controlStrategy - OWENS-only field that is not a TurbSim key",
+        "UF        analysis_type - OWENS-only field that is not a TurbSim key",
+        "line without comment separator",
+    ]
+
+    rendered_lines = OWENS.renderTurbsimInputLines(template_lines, sample_dlc_internal())
+
+    @test rendered_lines isa Vector{String}
+    @test rendered_lines == [
+        "False     Echo        - Echo input data to <RootName>.ech (flag)",
+        "12345 RandSeed1 - First random seed (-2147483648 to 2147483647)",
+        "17 NumGrid_Z - Vertical grid-point matrix dimension",
+        "0.25 TimeStep - Time step [s]",
+        "75.0 HubHt - Hub height [m] (should be > 0.5*GridHeight)",
+        "1.5 VFlowAng - Vertical mean flow (uptilt) angle [degrees]",
+        "\"B\" IECturbc - IEC turbulence characteristic",
+        "\"1EWM50\" IEC_WindType - IEC turbulence type",
+        "12.5 URef - Mean wind speed at the reference height [m/s]",
+        "placeholder URefExtra - Similar name that must not match URef",
+        "normal    controlStrategy - OWENS-only field that is not a TurbSim key",
+        "UF        analysis_type - OWENS-only field that is not a TurbSim key",
+        "line without comment separator",
+    ]
+    @test template_lines[2] ==
+          "40071     RandSeed1   - First random seed (-2147483648 to 2147483647)"
+end


### PR DESCRIPTION
## Summary
- extract TurbSim template rendering into a pure helper
- replace substring matching with exact template-key matching
- skip OWENS-only/time-series DLC fields explicitly before writing TurbSim input files
- add pinned tests for scalar replacement, substring non-matches, and non-mutating behavior

## Tests
- julia --project=. test/test_turbsim_template.jl
- julia --project=. -e 'using JuliaFormatter; format("src/runtime/DLCAnalysis.jl", verbose=true)'
- julia --project=. -e 'using JuliaFormatter; format("test/test_turbsim_template.jl", verbose=true)'
- git diff --check

References #49.