### PR TITLE
Support explicit node IDs for init conditions

### DIFF
--- a/src/core/utilities.jl
+++ b/src/core/utilities.jl
@@ -59,13 +59,17 @@ function safeakima(x, y, xpt; extrapolate = false)
 end
 
 """
-    setInitConditions(initDisps, numNodes, numDOFPerNode)
+    createInitCondArray(initDisps, numNodes, numDOFPerNode)
+    createInitCondArray(initDisps, nodeNumbers[, numDOFPerNode])
 
 Creates the formatted initial conditions array needed by OWENSFEA
 
 #Input
 * `initDisps`: an array of length numDOFPerNode specifying the initial displacement of each DOF
-* `numNodes`: the number of nodes in the given mesh
+* `numNodes`: the number of nodes in the given mesh. This preserves the legacy
+  `1:numNodes` node numbering behavior.
+* `nodeNumbers`: explicit mesh node numbers. Use this form when the mesh node IDs
+  are not contiguous or do not start at 1.
 * `numDOFPerNode`: the number of unconstrained degrees of freedom calculated in each node
 
 #Output
@@ -74,22 +78,40 @@ Creates the formatted initial conditions array needed by OWENSFEA
     initCond(i,2) local DOF number for init cond i.
     initCond(i,3) value for init cond i.
 """
-function createInitCondArray(initDisps, numNodes, numDOFPerNode)
-    if initDisps == zeros(length(initDisps))
-        initCond = []
-    else
-        initCond = zeros(numNodes*numDOFPerNode, 3)
-        for i = 1:length(initDisps)
-            if initDisps[i] != 0.0
-                dof_initCond = hcat(
-                    collect(1:numNodes),
-                    ones(Int, numNodes)*i,
-                    ones(numNodes)*initDisps[i],
-                )
-                initCond[((i-1)*numNodes+1):(i*numNodes), :] = dof_initCond
-            end
+function createInitCondArray(
+    initDisps,
+    numNodes::Integer,
+    numDOFPerNode::Integer = length(initDisps),
+)
+    numNodes >= 0 || throw(ArgumentError("numNodes must be non-negative"))
+    return createInitCondArray(initDisps, collect(1:numNodes), numDOFPerNode)
+end
+
+function createInitCondArray(
+    initDisps,
+    nodeNumbers::AbstractVector,
+    numDOFPerNode::Integer = length(initDisps),
+)
+    numDOFPerNode > 0 || throw(ArgumentError("numDOFPerNode must be positive"))
+    length(initDisps) <= numDOFPerNode ||
+        throw(ArgumentError("initDisps length cannot exceed numDOFPerNode"))
+
+    for nodeNumber in nodeNumbers
+        nodeNumber isa Integer || throw(ArgumentError("nodeNumbers must contain integers"))
+    end
+
+    if all(iszero, initDisps)
+        return []
+    end
+
+    activeDOFs = findall(!iszero, initDisps)
+    initCond = zeros(length(activeDOFs)*length(nodeNumbers), 3)
+    irow = 1
+    for idof in activeDOFs
+        for nodeNumber in nodeNumbers
+            initCond[irow, :] = [nodeNumber, idof, initDisps[idof]]
+            irow += 1
         end
-        initCond = initCond[vec(mapslices(col -> any(col .!= 0), initCond, dims = 2)), :] #removes rows of all zeros
     end
 
     return initCond

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,10 @@ end
     include("$path/test_uniform_wind.jl")
 end
 
+@testset "Initial Conditions" begin
+    include("$path/test_initial_conditions.jl")
+end
+
 @testset "SNL5MW With CACTUS One-Way Coupling, Preprepared Input Files" begin
     include("$path/SNL5MW_CACT_oneway_unit.jl")
 end

--- a/test/test_initial_conditions.jl
+++ b/test/test_initial_conditions.jl
@@ -1,0 +1,31 @@
+using Test
+import OWENS
+
+@testset "Initial condition arrays" begin
+    legacy_conditions = OWENS.createInitCondArray([0.0, 2.5, 0.0, -1.0], 3, 4)
+    @test legacy_conditions isa Matrix{Float64}
+    @test legacy_conditions == [
+        1.0 2.0 2.5
+        2.0 2.0 2.5
+        3.0 2.0 2.5
+        1.0 4.0 -1.0
+        2.0 4.0 -1.0
+        3.0 4.0 -1.0
+    ]
+
+    explicit_node_conditions = OWENS.createInitCondArray([1.0, 0.0, -0.5], [10, 20], 6)
+    @test explicit_node_conditions isa Matrix{Float64}
+    @test explicit_node_conditions == [
+        10.0 1.0 1.0
+        20.0 1.0 1.0
+        10.0 3.0 -0.5
+        20.0 3.0 -0.5
+    ]
+
+    @test OWENS.createInitCondArray(zeros(3), 2, 3) == []
+    @test OWENS.createInitCondArray(zeros(3), [10, 20], 3) == []
+
+    @test_throws ArgumentError OWENS.createInitCondArray([1.0], -1, 1)
+    @test_throws ArgumentError OWENS.createInitCondArray([1.0, 2.0], [1, 2], 1)
+    @test_throws ArgumentError OWENS.createInitCondArray([1.0], [1.5], 1)
+end


### PR DESCRIPTION
## Summary
- preserves createInitCondArray(initDisps, numNodes, numDOFPerNode) for legacy 1:numNodes behavior
- adds createInitCondArray(initDisps, nodeNumbers, numDOFPerNode) for meshes with explicit/non-contiguous node IDs
- adds pinned tests for legacy ordering, explicit node IDs, zero-displacement output, and input validation

## Tests
- julia --project=. test/test_initial_conditions.jl
- julia --project=. -e 'using JuliaFormatter; format("src/core/utilities.jl", verbose=true)'
- git diff --check

Notes
- I also tried julia --project=. test/testfloating.jl, but origin/master fails before reaching this behavior because HydroDyn resolves ./data/potential_flow_data/marin_semi.12d from the launch directory. That path issue is tracked separately in the open triage work.

References #49.