### PR TITLE
Derive MoorDyn line count and water depth

### DIFF
--- a/src/runtime/Unsteady.jl
+++ b/src/runtime/Unsteady.jl
@@ -1738,7 +1738,8 @@ function allocate_bottom(
     uddot_s_prp_n = Vector(uddot_s_ptfm_n[prpDOFs])
 
     jac = Array{Float32}(undef, numDOFPerNode*2, numDOFPerNode*2)
-    numMooringLines = 3
+    moordyn_summary = moorDynInputSummary(inputs.md_input_file)
+    numMooringLines = moordyn_summary.numMooringLines
 
     if inputs.dataOutputFilename == "none"
         hd_dataOutputFilename = "hydrodyn_temp.out"
@@ -1767,7 +1768,7 @@ function allocate_bottom(
         md_input_file = inputs.md_input_file,
         init_ptfm_pos = u_s_prp_n,
         interp_order = inputs.interpOrder,
-        WtrDpth = 200,
+        WtrDpth = moordyn_summary.waterDepth,
     )
 
     return bottom_totalNumDOF,
@@ -1802,6 +1803,64 @@ function validateMooringTensionBuffer(mooringTensions)
         ),
     )
     return mooringTensions
+end
+
+function moorDynSectionRows(lines, sectionName)
+    sectionName = uppercase(sectionName)
+    sectionStart = findfirst(lines) do line
+        stripped = uppercase(strip(line))
+        startswith(stripped, "-") && occursin(sectionName, stripped)
+    end
+    isnothing(sectionStart) &&
+        throw(ArgumentError("MoorDyn input is missing the $sectionName section"))
+
+    sectionEnd = findnext(lines, sectionStart+1) do line
+        startswith(strip(line), "-")
+    end
+    if isnothing(sectionEnd)
+        sectionEnd = length(lines)+1
+    end
+
+    return lines[(sectionStart+1):(sectionEnd-1)]
+end
+
+"""
+    moorDynInputSummary(md_input_file)
+
+Parse the MoorDyn input file fields needed by OWENS' floating initialization:
+the number of mooring lines and the water depth implied by fixed-point depths.
+"""
+function moorDynInputSummary(md_input_file)
+    isnothing(md_input_file) && throw(ArgumentError("md_input_file is required"))
+    lines = readlines(md_input_file)
+
+    fixedDepths = Float64[]
+    for row in moorDynSectionRows(lines, "POINTS")
+        fields = split(strip(row))
+        length(fields) >= 5 || continue
+        isnothing(tryparse(Int, fields[1])) && continue
+        if lowercase(fields[2]) == "fixed"
+            z = tryparse(Float64, fields[5])
+            isnothing(z) && continue
+            z <= 0.0 ||
+                throw(ArgumentError("Fixed MoorDyn point depth must be non-positive"))
+            push!(fixedDepths, -z)
+        end
+    end
+    isempty(fixedDepths) &&
+        throw(ArgumentError("MoorDyn input has no fixed points with parsable depth"))
+
+    numMooringLines = 0
+    for row in moorDynSectionRows(lines, "LINES")
+        fields = split(strip(row))
+        length(fields) >= 4 || continue
+        isnothing(tryparse(Int, fields[1])) && continue
+        numMooringLines += 1
+    end
+    numMooringLines > 0 ||
+        throw(ArgumentError("MoorDyn input has no parsable mooring lines"))
+
+    return (numMooringLines = numMooringLines, waterDepth = maximum(fixedDepths))
 end
 
 """

--- a/test/test_moordyn_buffers.jl
+++ b/test/test_moordyn_buffers.jl
@@ -1,6 +1,8 @@
 using Test
 import OWENS
 
+const test_path = splitdir(@__FILE__)[1]
+
 @testset "MoorDyn tension buffers" begin
     buffer = OWENS.mooringTensionBuffer(3)
     @test buffer isa Vector{Float32}
@@ -17,4 +19,69 @@ import OWENS
     @test_throws MethodError OWENS.mooringTensionBuffer(1.5)
     @test_throws ArgumentError OWENS.validateMooringTensionBuffer(zeros(Float32, 5))
     @test_throws ArgumentError OWENS.validateMooringTensionBuffer((1.0, 2.0))
+end
+
+@testset "MoorDyn input summary" begin
+    summary =
+        OWENS.moorDynInputSummary(joinpath(test_path, "data", "MoorDyn_CCT2_test.dat"))
+    @test summary isa NamedTuple{(:numMooringLines, :waterDepth),Tuple{Int64,Float64}}
+    @test summary.numMooringLines == 3
+    @test summary.waterDepth == 200.0
+
+    mktempdir() do dir
+        input_file = joinpath(dir, "MoorDyn_two_line.dat")
+        write(
+            input_file,
+            """
+            ---------------------- POINTS --------------------------------
+            ID Attachment X Y Z M V CdA CA
+            (-) (-) (m) (m) (m) (kg) (m^3) (m^2) (-)
+            1 Fixed 0.0 0.0 -50.0 0 0 0 0
+            2 Vessel 0.0 0.0 -5.0 0 0 0 0
+            3 Fixed 10.0 0.0 -75.0 0 0 0 0
+            4 Vessel 10.0 0.0 -5.0 0 0 0 0
+            ---------------------- LINES ---------------------------------
+            ID LineType AttachA AttachB UnstrLen NumSegs Outputs
+            (-) (-) (-) (-) (m) (-) (-)
+            1 main 1 2 80.0 10 -
+            2 main 3 4 90.0 10 -
+            ---------------------- SOLVER OPTIONS ------------------------
+            """,
+        )
+
+        summary = OWENS.moorDynInputSummary(input_file)
+        @test summary.numMooringLines == 2
+        @test summary.waterDepth == 75.0
+    end
+
+    mktempdir() do dir
+        input_file = joinpath(dir, "MoorDyn_no_fixed.dat")
+        write(
+            input_file,
+            """
+            ---------------------- POINTS --------------------------------
+            ID Attachment X Y Z M V CdA CA
+            1 Vessel 0.0 0.0 -5.0 0 0 0 0
+            ---------------------- LINES ---------------------------------
+            ID LineType AttachA AttachB UnstrLen NumSegs Outputs
+            1 main 1 1 80.0 10 -
+            """,
+        )
+        @test_throws ArgumentError OWENS.moorDynInputSummary(input_file)
+    end
+
+    mktempdir() do dir
+        input_file = joinpath(dir, "MoorDyn_no_lines.dat")
+        write(
+            input_file,
+            """
+            ---------------------- POINTS --------------------------------
+            ID Attachment X Y Z M V CdA CA
+            1 Fixed 0.0 0.0 -50.0 0 0 0 0
+            ---------------------- LINES ---------------------------------
+            ID LineType AttachA AttachB UnstrLen NumSegs Outputs
+            """,
+        )
+        @test_throws ArgumentError OWENS.moorDynInputSummary(input_file)
+    end
 end


### PR DESCRIPTION
## Summary
- parses MoorDyn input sections to derive mooring line count and water depth from fixed-point depths
- uses parsed line count for the MoorDyn tension buffer and parsed depth for MD_Init WtrDpth
- adds fixture and synthetic-input tests for normal and invalid MoorDyn files

## Tests
- julia --project=. test/test_moordyn_buffers.jl
- julia --project=. -e 'using JuliaFormatter; format("src/runtime/Unsteady.jl", verbose=true)'
- git diff --check

Stacked on #133 / codex/moordyn-tension-buffer.
References #49 and C6 floating runtime cleanup.