### PR TITLE
Resolve HydroDyn PotFile roots

### DIFF
--- a/src/core/utilities.jl
+++ b/src/core/utilities.jl
@@ -45,6 +45,108 @@ function simpleGenerator(inputs, genSpeed)
 
 end
 
+"""
+    hydrodynInputWithResolvedPotFile(hd_input_file, potflowfile)
+
+Return a HydroDyn input filename whose `PotFile` entry is absolute.
+
+HydroDyn resolves the `PotFile` line relative to the Julia process working
+directory, not necessarily relative to the HydroDyn input file. OWENS examples
+often launch from different directories, so this helper stages a temporary copy
+of the input file with the `PotFile` token replaced by an absolute root. An
+explicit `potflowfile` argument takes precedence. When `potflowfile` is missing,
+the existing HydroDyn `PotFile` value is resolved from the input file itself.
+"""
+function hydrodynInputWithResolvedPotFile(hd_input_file, potflowfile)
+    hd_input_file_string = string(hd_input_file)
+    if isnothing(hd_input_file) ||
+       lowercase(strip(hd_input_file_string)) == "none" ||
+       !isfile(hd_input_file_string)
+        return hd_input_file
+    end
+
+    lines = readlines(hd_input_file_string, keep = true)
+    potfile_line_index = findfirst(
+        line -> occursin(r"\bPotFile\b", line) && !startswith(strip(line), "!"),
+        lines,
+    )
+    isnothing(potfile_line_index) && return hd_input_file
+
+    potfile_line = lines[potfile_line_index]
+    potfile_root =
+        _resolvedHydroDynPotFileRoot(potfile_line, hd_input_file_string, potflowfile)
+    isnothing(potfile_root) && return hd_input_file
+
+    lines[potfile_line_index] = _hydrodynPotFileLineWithRoot(potfile_line, potfile_root)
+
+    staged_file = tempname() * ".dat"
+    open(staged_file, "w") do io
+        foreach(line -> write(io, line), lines)
+    end
+    return staged_file
+end
+
+function _resolvedHydroDynPotFileRoot(potfile_line, hd_input_file_string, potflowfile)
+    potflowfile_string = isnothing(potflowfile) ? "" : strip(string(potflowfile))
+    if !isempty(potflowfile_string) &&
+       !(lowercase(potflowfile_string) in ("none", "nothing"))
+        return abspath(potflowfile_string)
+    end
+
+    potfile_root = _hydrodynPotFileRootFromLine(potfile_line)
+    if isempty(potfile_root) || lowercase(potfile_root) in ("none", "nothing", "unused")
+        return nothing
+    end
+    isabspath(potfile_root) && return abspath(potfile_root)
+
+    hd_input_abspath = abspath(hd_input_file_string)
+    candidates = unique(
+        abspath.([
+            potfile_root,
+            joinpath(dirname(hd_input_abspath), potfile_root),
+            joinpath(dirname(dirname(hd_input_abspath)), potfile_root),
+        ]),
+    )
+    existing_root = findfirst(_hydrodynPotentialFlowRootExists, candidates)
+    !isnothing(existing_root) && return candidates[existing_root]
+
+    return abspath(joinpath(dirname(hd_input_abspath), potfile_root))
+end
+
+function _hydrodynPotFileRootFromLine(potfile_line)
+    line_body = chomp(potfile_line)
+    root_match = match(r"^\s*(?:\"([^\"]*)\"|(\S+))(?=\s+PotFile\b)", line_body)
+    if isnothing(root_match)
+        throw(ArgumentError("could not parse HydroDyn PotFile line: $(strip(line_body))"))
+    end
+    root =
+        isnothing(root_match.captures[1]) ? root_match.captures[2] : root_match.captures[1]
+    return strip(root)
+end
+
+function _hydrodynPotFileLineWithRoot(potfile_line, potfile_root)
+    line_ending =
+        endswith(potfile_line, "\r\n") ? "\r\n" : endswith(potfile_line, "\n") ? "\n" : ""
+    line_body = chomp(potfile_line)
+    line_match = match(r"^(\s*)(?:\"[^\"]*\"|\S+)(\s+PotFile\b.*)$", line_body)
+    if isnothing(line_match)
+        throw(ArgumentError("could not parse HydroDyn PotFile line: $(strip(line_body))"))
+    end
+    return string(
+        line_match.captures[1],
+        "\"$(potfile_root)\"",
+        line_match.captures[2],
+        line_ending,
+    )
+end
+
+function _hydrodynPotentialFlowRootExists(potfile_root)
+    return any(
+        ext -> isfile(string(potfile_root, ext)),
+        (".1", ".3", ".hst", ".12d", ".12s"),
+    )
+end
+
 function safeakima(x, y, xpt; extrapolate = false)
     if minimum(xpt)<(minimum(x)-(abs(minimum(x))*0.1+1e-4)) ||
        maximum(xpt)>(maximum(x)+abs(maximum(x))*0.1)

--- a/src/runtime/Unsteady.jl
+++ b/src/runtime/Unsteady.jl
@@ -1755,7 +1755,10 @@ function allocate_bottom(
     OWENSOpenFASTWrappers.HD_Init(;
         hdlib_filename = bin.hydrodynLibPath,
         output_root_name = hd_dataOutputFilename,
-        hd_input_file = inputs.hd_input_file,
+        hd_input_file = hydrodynInputWithResolvedPotFile(
+            inputs.hd_input_file,
+            inputs.potflowfile,
+        ),
         ss_input_file = inputs.ss_input_file,
         PotFile = inputs.potflowfile,
         t_initial = t[1],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,10 @@ end
     include("$path/test_moordyn_buffers.jl")
 end
 
+@testset "HydroDyn PotFile Resolver" begin
+    include("$path/test_hydrodyn_potfile.jl")
+end
+
 @testset "SNL5MW With CACTUS One-Way Coupling, Preprepared Input Files" begin
     include("$path/SNL5MW_CACT_oneway_unit.jl")
 end

--- a/test/test_hydrodyn_potfile.jl
+++ b/test/test_hydrodyn_potfile.jl
@@ -1,0 +1,63 @@
+using Test
+import OWENS
+
+const test_path = splitdir(@__FILE__)[1]
+
+function hydrodyn_potfile_line(filename)
+    return only(filter(line -> occursin(r"\bPotFile\b", line), readlines(filename)))
+end
+
+@testset "HydroDyn PotFile resolver" begin
+    hd_input_file = joinpath(test_path, "data", "HydroDyn_CCT2_test.dat")
+    staged_file = OWENS.hydrodynInputWithResolvedPotFile(hd_input_file, nothing)
+    expected_root =
+        abspath(joinpath(test_path, "data", "potential_flow_data", "marin_semi"))
+
+    @test staged_file isa String
+    @test staged_file != hd_input_file
+    @test isfile(staged_file)
+    @test occursin("\"$(expected_root)\"", hydrodyn_potfile_line(staged_file))
+    @test OWENS._hydrodynPotentialFlowRootExists(expected_root) === true
+
+    mktempdir() do dir
+        input_file = joinpath(dir, "HydroDyn_override.dat")
+        override_root = joinpath(dir, "explicit", "override_case")
+        write(
+            input_file,
+            """
+            ------- POTENTIAL FLOW INPUTS --------------------------------
+            "relative/default"    PotFile       - Root name of potential-flow model data
+            """,
+        )
+
+        staged_file = OWENS.hydrodynInputWithResolvedPotFile(input_file, override_root)
+        @test occursin("\"$(abspath(override_root))\"", hydrodyn_potfile_line(staged_file))
+    end
+
+    mktempdir() do dir
+        no_potfile_input = joinpath(dir, "HydroDyn_no_potfile.dat")
+        write(no_potfile_input, "False Echo - Echo input data to <RootName>.ech\n")
+        @test OWENS.hydrodynInputWithResolvedPotFile(no_potfile_input, nothing) ==
+              no_potfile_input
+
+        unused_potfile_input = joinpath(dir, "HydroDyn_unused_potfile.dat")
+        write(
+            unused_potfile_input,
+            "\"unused\"    PotFile       - Root name of potential-flow model data\n",
+        )
+        @test OWENS.hydrodynInputWithResolvedPotFile(unused_potfile_input, nothing) ==
+              unused_potfile_input
+
+        malformed_potfile_input = joinpath(dir, "HydroDyn_malformed_potfile.dat")
+        write(
+            malformed_potfile_input,
+            "      PotFile       - missing potential-flow root\n",
+        )
+        @test_throws ArgumentError OWENS.hydrodynInputWithResolvedPotFile(
+            malformed_potfile_input,
+            nothing,
+        )
+    end
+
+    @test OWENS.hydrodynInputWithResolvedPotFile("none", nothing) == "none"
+end


### PR DESCRIPTION
## Summary
- stage HydroDyn input files with absolute PotFile roots so HydroDyn can find WAMIT data independent of Julia's launch directory
- prefer explicit potflowfile overrides, otherwise resolve existing HydroDyn PotFile entries relative to the input file and nearby example layouts
- add focused tests for fixture resolution, explicit overrides, missing/unused entries, malformed lines, and sentinel handling

Stacked on #134. References #83 and the floating-runtime PotFile path cleanup in ISSUE_TODO_TRIAGE.md.

## Tests
- julia --project=. test/test_hydrodyn_potfile.jl
- julia --project=. test/test_moordyn_buffers.jl
- julia --project=. test/testfloating.jl
- git diff --check