### PR TITLE
Cleanup partial OpenFAST initialization

### DIFF
--- a/src/core/utilities.jl
+++ b/src/core/utilities.jl
@@ -168,7 +168,7 @@ function completedHistoryRanges(last_saved_index::Integer, numTS::Integer)
 end
 
 """
-    endOpenFASTModules(inputs; openfast=OWENSOpenFASTWrappers, platform_initialized=inputs.platformActive, ad_initialized=inputs.AD15On)
+    endOpenFASTModules(inputs; openfast=OWENSOpenFASTWrappers, platform_initialized=inputs.platformActive, hd_initialized=platform_initialized, md_initialized=platform_initialized, ad_initialized=inputs.AD15On)
 
 End initialized OpenFAST native modules without masking an upstream simulation
 error.
@@ -181,6 +181,8 @@ function endOpenFASTModules(
     inputs;
     openfast = OWENSOpenFASTWrappers,
     platform_initialized = inputs.platformActive,
+    hd_initialized = platform_initialized,
+    md_initialized = platform_initialized,
     ad_initialized = inputs.AD15On,
     warn_on_error = true,
 )
@@ -198,8 +200,10 @@ function endOpenFASTModules(
         end
     end
 
-    if platform_initialized
+    if hd_initialized
         cleanup("HydroDyn", openfast.HD_End)
+    end
+    if md_initialized
         cleanup("MoorDyn", openfast.MD_End)
     end
     if ad_initialized

--- a/src/runtime/Unsteady.jl
+++ b/src/runtime/Unsteady.jl
@@ -105,164 +105,181 @@ function Unsteady(
     rbData,
     rbDataHist = allocate_general(inputs, topModel, topMesh, numDOFPerNode, numTS, assembly)
 
-    if inputs.topsideOn
-        # Allocate memory for topside
-        u_s,
-        udot_s,
-        uddot_s,
-        u_sm1,
-        topDispData1,
-        topDispData2,
-        topElStrain,
-        gb_s,
-        gbDot_s,
-        gbDotDot_s,
-        azi_s,
-        Omega_s,
-        OmegaDot_s,
-        genTorque_s,
-        torqueDriveShaft_s,
-        topFexternal,
-        topFexternal_hist =
-            allocate_topside(inputs, topMesh, topEl, topModel, numDOFPerNode, u_s, assembly)
-    end
-    ## Hydrodynamics/mooring module initialization and coupling variables
-    if inputs.platformActive
-        bottom_totalNumDOF,
-        u_s_ptfm_n,
-        udot_s_ptfm_n,
-        uddot_s_ptfm_n,
-        u_sm1_ptfm_n,
-        bottomDispData,
-        prpDOFs,
-        u_s_prp_n,
-        udot_s_prp_n,
-        uddot_s_prp_n,
-        jac,
-        numMooringLines,
-        FHydro_n,
-        FMooring_n,
-        outVals,
-        mooringTensions = allocate_bottom(
-            t,
-            numTS,
-            delta_t,
-            inputs,
-            bottomMesh,
-            bottomEl,
-            bottomModel,
-            bin,
-            numDOFPerNode,
-        )
-    end
-
-    ## Rotor mode initialization
-    rotorSpeedForGenStart = initialize_generator!(inputs)
-
-    ## Structural dynamics initialization
-    if isnothing(topElStorage) && inputs.topsideOn
-        topElStorage = OWENSFEA.initialElementCalculations(topModel, topEl, topMesh) #perform initial element calculations for conventional structural dynamics analysis
-    end
-    if isnothing(bottomElStorage) && inputs.platformActive
-        bottomElStorage =
-            OWENSFEA.initialElementCalculations(bottomModel, bottomEl, bottomMesh) #perform initial element calculations for conventional structural dynamics analysis
-    end
-    if inputs.analysisType=="ROM"
-        if inputs.topsideOn
-            top_rom,
-            topJointTransformTrans,
-            u_sRed,
-            udot_sRed,
-            uddot_sRed,
-            topBC,
-            u_s2,
-            udot_s2,
-            uddot_s2,
-            top_invPhi,
-            eta_s,
-            etadot_s,
-            etaddot_s =
-                initialize_ROM(topElStorage, topModel, topMesh, topEl, u_s, udot_s, uddot_s)
-
-            topDispData1.eta_s = eta_s
-            topDispData1.etadot_s = etadot_s
-            topDispData1.etaddot_s = etaddot_s
-            topDispData2.eta_s = eta_s
-            topDispData2.etadot_s = etadot_s
-            topDispData2.etaddot_s = etaddot_s
-        end
-
-        if inputs.platformActive
-
-            bottom_rom,
-            bottomJointTransformTrans,
-            u_sRed_ptfm_n,
-            udot_sRed_ptfm_n,
-            uddot_sRed_ptfm_n,
-            bottomBC,
-            u_s2_ptfm_n,
-            udot_s2_ptfm_n,
-            uddot_s2_ptfm_n,
-            bottom_invPhi,
-            eta_s_ptfm_n,
-            etadot_s_ptfm_n,
-            etaddot_s_ptfm_n = initialize_ROM(
-                bottomElStorage,
-                bottomModel,
-                bottomMesh,
-                bottomEl,
-                u_s_ptfm_n,
-                udot_s_ptfm_n,
-                uddot_s_ptfm_n,
-            )
-
-            bottomDispData.eta_s = eta_s_ptfm_n
-            bottomDispData.etadot_s = etadot_s_ptfm_n
-            bottomDispData.etaddot_s = etaddot_s_ptfm_n
-        end
-    end
-
-    if inputs.topsideOn
-        topsideMass, topsideMOI, topsideCG =
-            OWENSFEA.calculateStructureMassProps(topElStorage)
-        topModel.jointTransform, topModel.reducedDOFList =
-            OWENSFEA.createJointTransform(topModel.joint, topMesh.numNodes, 6) #creates a joint transform to constrain model degrees of freedom (DOF) consistent with joint constraints
-
-        if inputs.platformActive
-            hydro_topside_nodal_coupling!(
-                bottomModel,
-                bottomMesh,
-                topsideMass,
-                topModel,
-                topsideCG,
-                topsideMOI,
-                numDOFPerNode,
-            )
-        end # if inputs.platformActive
-    end # if inputs.topsideOn
-
-    if inputs.topsideOn
-        uHist[1, :] = u_s          #store initial condition
-        aziHist[1] = azi_s
-        OmegaHist[1] = Omega_s
-        OmegaDotHist[1] = OmegaDot_s
-        FReactionsm1 = zeros(topMesh.numNodes*6)
-        FReactionHist[1, :] = FReactionsm1
-        topFReaction_j = FReactionsm1
-        # topWeight = [0.0, 0.0, topsideMass*-9.80665, 0.0, 0.0, 0.0] #TODO: propogate gravity, or remove since this isn't used
-        gbHist[1] = gb_s
-        gbDotHist[1] = gbDot_s
-        gbDotDotHist[1] = gbDotDot_s
-        rbDataHist[1, :] = zeros(9)
-        genTorque[1] = genTorque_s
-        torqueDriveShaft[1] = torqueDriveShaft_s
-    end
-
-    if inputs.platformActive
-        uHist_prp[1, :] = u_s_prp_n
-    end
+    openfast_platform_initialized = false
 
     try
+        if inputs.topsideOn
+            # Allocate memory for topside
+            u_s,
+            udot_s,
+            uddot_s,
+            u_sm1,
+            topDispData1,
+            topDispData2,
+            topElStrain,
+            gb_s,
+            gbDot_s,
+            gbDotDot_s,
+            azi_s,
+            Omega_s,
+            OmegaDot_s,
+            genTorque_s,
+            torqueDriveShaft_s,
+            topFexternal,
+            topFexternal_hist = allocate_topside(
+                inputs,
+                topMesh,
+                topEl,
+                topModel,
+                numDOFPerNode,
+                u_s,
+                assembly,
+            )
+        end
+        ## Hydrodynamics/mooring module initialization and coupling variables
+        if inputs.platformActive
+            bottom_totalNumDOF,
+            u_s_ptfm_n,
+            udot_s_ptfm_n,
+            uddot_s_ptfm_n,
+            u_sm1_ptfm_n,
+            bottomDispData,
+            prpDOFs,
+            u_s_prp_n,
+            udot_s_prp_n,
+            uddot_s_prp_n,
+            jac,
+            numMooringLines,
+            FHydro_n,
+            FMooring_n,
+            outVals,
+            mooringTensions = allocate_bottom(
+                t,
+                numTS,
+                delta_t,
+                inputs,
+                bottomMesh,
+                bottomEl,
+                bottomModel,
+                bin,
+                numDOFPerNode,
+            )
+            openfast_platform_initialized = true
+        end
+
+        ## Rotor mode initialization
+        rotorSpeedForGenStart = initialize_generator!(inputs)
+
+        ## Structural dynamics initialization
+        if isnothing(topElStorage) && inputs.topsideOn
+            topElStorage = OWENSFEA.initialElementCalculations(topModel, topEl, topMesh) #perform initial element calculations for conventional structural dynamics analysis
+        end
+        if isnothing(bottomElStorage) && inputs.platformActive
+            bottomElStorage =
+                OWENSFEA.initialElementCalculations(bottomModel, bottomEl, bottomMesh) #perform initial element calculations for conventional structural dynamics analysis
+        end
+        if inputs.analysisType=="ROM"
+            if inputs.topsideOn
+                top_rom,
+                topJointTransformTrans,
+                u_sRed,
+                udot_sRed,
+                uddot_sRed,
+                topBC,
+                u_s2,
+                udot_s2,
+                uddot_s2,
+                top_invPhi,
+                eta_s,
+                etadot_s,
+                etaddot_s = initialize_ROM(
+                    topElStorage,
+                    topModel,
+                    topMesh,
+                    topEl,
+                    u_s,
+                    udot_s,
+                    uddot_s,
+                )
+
+                topDispData1.eta_s = eta_s
+                topDispData1.etadot_s = etadot_s
+                topDispData1.etaddot_s = etaddot_s
+                topDispData2.eta_s = eta_s
+                topDispData2.etadot_s = etadot_s
+                topDispData2.etaddot_s = etaddot_s
+            end
+
+            if inputs.platformActive
+
+                bottom_rom,
+                bottomJointTransformTrans,
+                u_sRed_ptfm_n,
+                udot_sRed_ptfm_n,
+                uddot_sRed_ptfm_n,
+                bottomBC,
+                u_s2_ptfm_n,
+                udot_s2_ptfm_n,
+                uddot_s2_ptfm_n,
+                bottom_invPhi,
+                eta_s_ptfm_n,
+                etadot_s_ptfm_n,
+                etaddot_s_ptfm_n = initialize_ROM(
+                    bottomElStorage,
+                    bottomModel,
+                    bottomMesh,
+                    bottomEl,
+                    u_s_ptfm_n,
+                    udot_s_ptfm_n,
+                    uddot_s_ptfm_n,
+                )
+
+                bottomDispData.eta_s = eta_s_ptfm_n
+                bottomDispData.etadot_s = etadot_s_ptfm_n
+                bottomDispData.etaddot_s = etaddot_s_ptfm_n
+            end
+        end
+
+        if inputs.topsideOn
+            topsideMass, topsideMOI, topsideCG =
+                OWENSFEA.calculateStructureMassProps(topElStorage)
+            topModel.jointTransform, topModel.reducedDOFList =
+                OWENSFEA.createJointTransform(topModel.joint, topMesh.numNodes, 6) #creates a joint transform to constrain model degrees of freedom (DOF) consistent with joint constraints
+
+            if inputs.platformActive
+                hydro_topside_nodal_coupling!(
+                    bottomModel,
+                    bottomMesh,
+                    topsideMass,
+                    topModel,
+                    topsideCG,
+                    topsideMOI,
+                    numDOFPerNode,
+                )
+            end # if inputs.platformActive
+        end # if inputs.topsideOn
+
+        if inputs.topsideOn
+            uHist[1, :] = u_s          #store initial condition
+            aziHist[1] = azi_s
+            OmegaHist[1] = Omega_s
+            OmegaDotHist[1] = OmegaDot_s
+            FReactionsm1 = zeros(topMesh.numNodes*6)
+            FReactionHist[1, :] = FReactionsm1
+            topFReaction_j = FReactionsm1
+            # topWeight = [0.0, 0.0, topsideMass*-9.80665, 0.0, 0.0, 0.0] #TODO: propogate gravity, or remove since this isn't used
+            gbHist[1] = gb_s
+            gbDotHist[1] = gbDot_s
+            gbDotDotHist[1] = gbDotDot_s
+            rbDataHist[1, :] = zeros(9)
+            genTorque[1] = genTorque_s
+            torqueDriveShaft[1] = torqueDriveShaft_s
+        end
+
+        if inputs.platformActive
+            uHist_prp[1, :] = u_s_prp_n
+        end
+
         #..................................................................
         #                          INITIAL SOLVE
         #..................................................................
@@ -1310,7 +1327,7 @@ function Unsteady(
         topFexternal_hist[state_range, :],
         rbDataHist[state_range, :]
     finally
-        endOpenFASTModules(inputs)
+        endOpenFASTModules(inputs; platform_initialized = openfast_platform_initialized)
     end
 end
 
@@ -1738,6 +1755,8 @@ function allocate_bottom(
     bottomModel,
     bin,
     numDOFPerNode,
+    ;
+    openfast = OWENSOpenFASTWrappers,
 )
     if isnothing(bottomModel)
         error("bottomMesh must be specified if OWENS.Inputs.platformActive")
@@ -1779,27 +1798,43 @@ function allocate_bottom(
     outVals = Vector{Float32}(undef, numDOFPerNode+1) # Rigid body displacement in 6DOF + wave elevation
     mooringTensions = mooringTensionBuffer(numMooringLines)
 
-    OWENSOpenFASTWrappers.HD_Init(;
-        hdlib_filename = bin.hydrodynLibPath,
-        output_root_name = hd_dataOutputFilename,
-        hd_input_file = hydrodynInputWithResolvedPotFile(
-            inputs.hd_input_file,
-            inputs.potflowfile,
-        ),
-        ss_input_file = inputs.ss_input_file,
-        PotFile = inputs.potflowfile,
-        t_initial = t[1],
-        dt = delta_t,
-        t_max = t[1]+(numTS-1)*delta_t,
-        interp_order = inputs.interpOrder,
-    )
-    OWENSOpenFASTWrappers.MD_Init(;
-        mdlib_filename = bin.moordynLibPath,
-        md_input_file = inputs.md_input_file,
-        init_ptfm_pos = u_s_prp_n,
-        interp_order = inputs.interpOrder,
-        WtrDpth = moordyn_summary.waterDepth,
-    )
+    hd_initialized = false
+    md_initialized = false
+    try
+        openfast.HD_Init(;
+            hdlib_filename = bin.hydrodynLibPath,
+            output_root_name = hd_dataOutputFilename,
+            hd_input_file = hydrodynInputWithResolvedPotFile(
+                inputs.hd_input_file,
+                inputs.potflowfile,
+            ),
+            ss_input_file = inputs.ss_input_file,
+            PotFile = inputs.potflowfile,
+            t_initial = t[1],
+            dt = delta_t,
+            t_max = t[1]+(numTS-1)*delta_t,
+            interp_order = inputs.interpOrder,
+        )
+        hd_initialized = true
+
+        openfast.MD_Init(;
+            mdlib_filename = bin.moordynLibPath,
+            md_input_file = inputs.md_input_file,
+            init_ptfm_pos = u_s_prp_n,
+            interp_order = inputs.interpOrder,
+            WtrDpth = moordyn_summary.waterDepth,
+        )
+        md_initialized = true
+    catch
+        endOpenFASTModules(
+            inputs;
+            openfast = openfast,
+            hd_initialized = hd_initialized,
+            md_initialized = md_initialized,
+            ad_initialized = false,
+        )
+        rethrow()
+    end
 
     return bottom_totalNumDOF,
     u_s_ptfm_n,

--- a/test/test_openfast_cleanup.jl
+++ b/test/test_openfast_cleanup.jl
@@ -52,4 +52,137 @@ import OWENS
     )
     @test calls_with_flags == [:endTurb]
     @test isempty(errors)
+
+    partial_calls = Symbol[]
+    errors = OWENS.endOpenFASTModules(
+        inputs;
+        openfast = (
+            HD_End = () -> push!(partial_calls, :HD_End),
+            MD_End = () -> push!(partial_calls, :MD_End),
+            endTurb = () -> push!(partial_calls, :endTurb),
+        ),
+        hd_initialized = true,
+        md_initialized = false,
+        ad_initialized = false,
+    )
+    @test partial_calls == [:HD_End]
+    @test isempty(errors)
+end
+
+@testset "OpenFAST allocation cleanup" begin
+    mktempdir() do dir
+        md_input_file = joinpath(dir, "MoorDyn_minimal.dat")
+        write(
+            md_input_file,
+            """
+            ---------------------- POINTS --------------------------------
+            ID Attachment X Y Z M V CdA CA
+            1 Fixed 0.0 0.0 -75.0 0 0 0 0
+            2 Vessel 0.0 0.0 -5.0 0 0 0 0
+            ---------------------- LINES ---------------------------------
+            ID LineType AttachA AttachB UnstrLen NumSegs Outputs
+            1 main 1 2 80.0 10 -
+            ---------------------- SOLVER OPTIONS ------------------------
+            """,
+        )
+
+        inputs = (
+            dataOutputFilename = "none",
+            hd_input_file = "none",
+            ss_input_file = "none",
+            md_input_file = md_input_file,
+            potflowfile = nothing,
+            interpOrder = 2,
+            platformActive = true,
+            AD15On = false,
+        )
+        bottom_mesh = (numNodes = 1,)
+        bottom_el = (;)
+        bottom_model = (initCond = zeros(0, 3),)
+        bin = (hydrodynLibPath = "libhydrodyn", moordynLibPath = "libmoordyn")
+        times = range(0.0, length = 2, step = 0.1)
+
+        init_calls = Symbol[]
+        init_kwargs = Dict{Symbol,Any}()
+        openfast = (
+            HD_Init = (; kwargs...) -> begin
+                push!(init_calls, :HD_Init)
+                init_kwargs[:hd_input_file] = kwargs[:hd_input_file]
+                nothing
+            end,
+            MD_Init = (; kwargs...) -> begin
+                push!(init_calls, :MD_Init)
+                init_kwargs[:WtrDpth] = kwargs[:WtrDpth]
+                nothing
+            end,
+            HD_End = () -> push!(init_calls, :HD_End),
+            MD_End = () -> push!(init_calls, :MD_End),
+            endTurb = () -> push!(init_calls, :endTurb),
+        )
+
+        result = OWENS.allocate_bottom(
+            times,
+            2,
+            0.1,
+            inputs,
+            bottom_mesh,
+            bottom_el,
+            bottom_model,
+            bin,
+            6;
+            openfast = openfast,
+        )
+        @test result[1] == 6
+        @test result[12] == 1
+        @test init_calls == [:HD_Init, :MD_Init]
+        @test init_kwargs[:hd_input_file] == "none"
+        @test init_kwargs[:WtrDpth] == 75.0
+
+        partial_calls = Symbol[]
+        md_fails = (
+            HD_Init = (; kwargs...) -> push!(partial_calls, :HD_Init),
+            MD_Init = (; kwargs...) -> begin
+                push!(partial_calls, :MD_Init)
+                error("moordyn init failed")
+            end,
+            HD_End = () -> push!(partial_calls, :HD_End),
+            MD_End = () -> push!(partial_calls, :MD_End),
+            endTurb = () -> push!(partial_calls, :endTurb),
+        )
+        @test_throws ErrorException OWENS.allocate_bottom(
+            times,
+            2,
+            0.1,
+            inputs,
+            bottom_mesh,
+            bottom_el,
+            bottom_model,
+            bin,
+            6;
+            openfast = md_fails,
+        )
+        @test partial_calls == [:HD_Init, :MD_Init, :HD_End]
+
+        hd_calls = Symbol[]
+        hd_fails = (
+            HD_Init = (; kwargs...) -> error("hydrodyn init failed"),
+            MD_Init = (; kwargs...) -> push!(hd_calls, :MD_Init),
+            HD_End = () -> push!(hd_calls, :HD_End),
+            MD_End = () -> push!(hd_calls, :MD_End),
+            endTurb = () -> push!(hd_calls, :endTurb),
+        )
+        @test_throws ErrorException OWENS.allocate_bottom(
+            times,
+            2,
+            0.1,
+            inputs,
+            bottom_mesh,
+            bottom_el,
+            bottom_model,
+            bin,
+            6;
+            openfast = hd_fails,
+        )
+        @test isempty(hd_calls)
+    end
 end


### PR DESCRIPTION
Stacked on #137.\n\nThis closes the allocation-level gap left after moving the main Unsteady path to finally-based cleanup. The platform OpenFAST cleanup state now distinguishes HydroDyn and MoorDyn initialization, and allocate_bottom cleans up HydroDyn if MoorDyn initialization fails before rethrowing. The outer Unsteady cleanup now starts before platform allocation and only tears down platform modules after allocation succeeds.\n\nValidated locally with:\n- julia --project=. test/test_openfast_cleanup.jl\n- julia --project=. test/test_hydrodyn_potfile.jl\n- julia --project=. test/test_unsteady_history_ranges.jl\n- julia --project=. test/testfloating.jl\n- git diff --check\n\nReferences #49 and C6 floating/runtime cleanup.