### PR TITLE
Validate saved VTK stress histories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,13 @@ new*
 *.bts
 *.jld*
 *.cov
+
+# Generated test logs
+test/*.log
+
+# Generated XFOIL and airfoil polar workflow outputs
+examples/NACA0018/
+examples/airfoils/NACA_0018_decreasing_aoa.dat
+examples/airfoils/NACA_0018_increasing_aoa.dat
+examples/airfoils/S8038_top_symmetric.csv
+examples/airfoils/S8038_top_symmetric.dat

--- a/src/preprocessing/gxbeam_conversion.jl
+++ b/src/preprocessing/gxbeam_conversion.jl
@@ -261,6 +261,7 @@ function OWENSVTK(
 )
 
     println("Saving VTK time domain files")
+    _validate_vtk_save_indices(tsave_idx, length(t))
     userPointNames=[
         "EA",
         "rhoA",
@@ -346,6 +347,8 @@ function OWENSVTK(
 
     azi=aziHist#./aziHist*1e-6
     # VTKsaveName = "$path/vtk/$(windINPfilename[1:end-4])"
+    stress_saved = _saved_vtk_stress_history(stress, tsave_idx, length(t))
+
     OWENS.OWENSFEA_VTK(
         VTKsaveName,
         t[tsave_idx],
@@ -357,9 +360,38 @@ function OWENSVTK(
         azi = azi[tsave_idx],
         userPointNames,
         userPointData,
-        stress,
+        stress = stress_saved,
     )
 
+end
+
+function _saved_vtk_stress_history(stress, tsave_idx, nt)
+    isnothing(stress) && return nothing
+    _validate_vtk_save_indices(tsave_idx, nt)
+    ndims(stress) == 3 ||
+        throw(ArgumentError("stress must have dimensions (time, point, cross_section)"))
+
+    nsave = length(tsave_idx)
+    nstress_time = size(stress, 1)
+    if nstress_time == nt
+        return stress[tsave_idx, :, :]
+    elseif nstress_time == nsave
+        return stress
+    end
+
+    throw(
+        DimensionMismatch(
+            "stress time dimension $nstress_time must match the full time history length $nt or saved time count $nsave",
+        ),
+    )
+end
+
+function _validate_vtk_save_indices(tsave_idx, nt)
+    all(i -> i isa Integer && !(i isa Bool), tsave_idx) ||
+        throw(ArgumentError("tsave_idx entries must be integer time indices"))
+    all(i -> 1 <= i <= nt, tsave_idx) ||
+        throw(ArgumentError("tsave_idx entries must be within the full time history"))
+    return nothing
 end
 
 function OWENSFEA_VTK(
@@ -810,6 +842,21 @@ function mywrite_vtk(
     npoint = length(assembly.points)
     ncross = isnothing(sections) ? 1 : size(sections, 2)
     nelem = length(assembly.elements)
+    _validate_vtk_history_inputs(
+        history,
+        t,
+        assembly,
+        sections;
+        theta_x,
+        theta_y,
+        theta_z,
+        delta_x,
+        delta_y,
+        delta_z,
+        userPointNames,
+        userPointData,
+        stress,
+    )
 
     paraview_collection(name) do pvd
 
@@ -952,6 +999,8 @@ function mywrite_vtk(
                             for ip = 1:npoint
                                 data[:, li[:, ip]] = stress[current_step, ip, :]
                             end
+                        else
+                            continue
                         end
                     else
                         for ip = 1:npoint
@@ -973,6 +1022,82 @@ function mywrite_vtk(
 
             pvd[t[current_step]] = vtkfile
         end
+    end
+
+    return nothing
+end
+
+function _validate_vtk_history_inputs(
+    history,
+    t,
+    assembly,
+    sections;
+    theta_x = zero(t),
+    theta_y = zero(t),
+    theta_z = zero(t),
+    delta_x = zero(t),
+    delta_y = zero(t),
+    delta_z = zero(t),
+    userPointNames = nothing,
+    userPointData = nothing,
+    stress = nothing,
+)
+    ntime = length(t)
+    npoint = length(assembly.points)
+
+    length(history) == ntime ||
+        throw(ArgumentError("VTK history length must match the time vector length"))
+
+    for (name, values) in (
+        (:theta_x, theta_x),
+        (:theta_y, theta_y),
+        (:theta_z, theta_z),
+        (:delta_x, delta_x),
+        (:delta_y, delta_y),
+        (:delta_z, delta_z),
+    )
+        length(values) == ntime ||
+            throw(ArgumentError("VTK $(name) length must match the time vector length"))
+    end
+
+    ncross = 1
+    if !isnothing(sections)
+        size(sections, 1) == 3 ||
+            throw(ArgumentError("VTK sections must have first dimension size 3"))
+        if ndims(sections) > 2
+            size(sections, 3) == npoint ||
+                throw(ArgumentError("VTK section point count must match assembly points"))
+        end
+        ncross = size(sections, 2)
+    end
+
+    if isnothing(userPointData)
+        isnothing(userPointNames) ||
+            throw(ArgumentError("VTK userPointNames require matching userPointData"))
+    else
+        isnothing(userPointNames) &&
+            throw(ArgumentError("VTK userPointData require matching userPointNames"))
+        ndims(userPointData) == 3 || throw(
+            ArgumentError("VTK userPointData must have dimensions (field, time, point)"),
+        )
+        length(userPointNames) == size(userPointData, 1) ||
+            throw(ArgumentError("VTK userPointNames count must match userPointData"))
+        size(userPointData, 2) == ntime ||
+            throw(ArgumentError("VTK userPointData time count must match the time vector"))
+        size(userPointData, 3) == npoint ||
+            throw(ArgumentError("VTK userPointData point count must match assembly points"))
+    end
+
+    if !isnothing(stress)
+        ndims(stress) == 3 || throw(
+            ArgumentError("VTK stress must have dimensions (time, point, cross-section)"),
+        )
+        size(stress, 1) == ntime ||
+            throw(ArgumentError("VTK stress time count must match the time vector"))
+        size(stress, 2) == npoint ||
+            throw(ArgumentError("VTK stress point count must match assembly points"))
+        size(stress, 3) == ncross ||
+            throw(ArgumentError("VTK stress cross-section count must match sections"))
     end
 
     return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,10 @@ end
     include("$path/test_openfast_cleanup.jl")
 end
 
+@testset "VTK History Output" begin
+    include("$path/test_visualization_history.jl")
+end
+
 @testset "SNL5MW With CACTUS One-Way Coupling, Preprepared Input Files" begin
     include("$path/SNL5MW_CACT_oneway_unit.jl")
 end

--- a/test/test_visualization_history.jl
+++ b/test/test_visualization_history.jl
@@ -1,0 +1,160 @@
+using Test
+import OWENS
+
+@testset "VTK stress history selection" begin
+    full_stress = reshape(collect(1.0:24.0), 4, 3, 2)
+    tsave_idx = [1, 3]
+
+    saved_stress = OWENS._saved_vtk_stress_history(full_stress, tsave_idx, 4)
+    @test size(saved_stress) == (2, 3, 2)
+    @test saved_stress[1, 1, 1] == 1.0
+    @test saved_stress[1, 3, 2] == full_stress[1, 3, 2]
+    @test saved_stress[2, 2, 1] == full_stress[3, 2, 1]
+    @test saved_stress[2, 3, 2] == 23.0
+
+    presliced_stress = full_stress[tsave_idx, :, :]
+    @test OWENS._saved_vtk_stress_history(presliced_stress, tsave_idx, 4) ===
+          presliced_stress
+    @test isnothing(OWENS._saved_vtk_stress_history(nothing, tsave_idx, 4))
+
+    malformed_stress = reshape(collect(1.0:18.0), 3, 3, 2)
+    @test_throws DimensionMismatch OWENS._saved_vtk_stress_history(
+        malformed_stress,
+        tsave_idx,
+        4,
+    )
+    @test_throws ArgumentError OWENS._saved_vtk_stress_history(ones(2, 3), tsave_idx, 4)
+    @test_throws ArgumentError OWENS._saved_vtk_stress_history(full_stress, [1.0, 3.0], 4)
+    @test_throws ArgumentError OWENS._saved_vtk_stress_history(full_stress, [true, false], 4)
+    @test_throws ArgumentError OWENS._saved_vtk_stress_history(full_stress, [1, 5], 4)
+end
+
+@testset "VTK history input validation" begin
+    assembly = (; points = [1, 2, 3], elements = [1, 2])
+    history = [:state1, :state2]
+    time = [0.0, 0.1]
+    sections = zeros(3, 2, 3)
+    user_point_names = ["load", "Principal_Surface_Layer_Stress"]
+    user_point_data = zeros(2, 2, 3)
+    stress = zeros(2, 3, 2)
+
+    @test OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        theta_z = [0.0, pi / 2],
+        userPointNames = user_point_names,
+        userPointData = user_point_data,
+        stress,
+    ) === nothing
+    @test OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        userPointNames = user_point_names,
+        userPointData = user_point_data,
+        stress = nothing,
+    ) === nothing
+
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        [:state1],
+        time,
+        assembly,
+        sections,
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        theta_z = [0.0],
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        zeros(2, 2, 3),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        zeros(3, 2, 2),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        userPointNames = user_point_names,
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        userPointData = user_point_data,
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        userPointNames = ["load"],
+        userPointData = user_point_data,
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        userPointNames = user_point_names,
+        userPointData = zeros(2, 2),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        userPointNames = user_point_names,
+        userPointData = zeros(2, 1, 3),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        userPointNames = user_point_names,
+        userPointData = zeros(2, 2, 2),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        stress = zeros(2, 3),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        stress = zeros(1, 3, 2),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        stress = zeros(2, 2, 2),
+    )
+    @test_throws ArgumentError OWENS._validate_vtk_history_inputs(
+        history,
+        time,
+        assembly,
+        sections;
+        stress = zeros(2, 3, 1),
+    )
+end


### PR DESCRIPTION
## Summary
- slice full stress histories to saved VTK timesteps before writing
- validate VTK history, user point data, section, stress, and save-index shapes before output
- ignore generated local test/XFOIL workflow artifacts

## Tests
- julia --project=. test/test_visualization_history.jl
- julia --project=. test/runtests.jl (new VTK block passes; existing SNL5MW CACTUS history arrays still error with (4,75,50) vs (4,75,49) at test/SNL5MW_CACT_oneway_unit.jl:844-849)

References #47 and #49