### PR TITLE
Add output data channel registry

### DIFF
--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -13,3 +13,20 @@ CurrentModule = OWENS
 ```@autodocs
 Modules = [OWENS]
 ```
+
+## Output Data Channels
+
+`OWENS.outputData` writes a root-level HDF5 file and annotates each dataset
+with channel metadata. Use `output_data_channels()` when postprocessing tools,
+validation dashboards, or GUI code need stable units and axis labels without
+hard-coding dataset positions.
+
+The public helpers are:
+
+- `ResultChannel`
+- `output_data_channels()`
+- `output_data_channel(name)`
+- `output_data_channel_names()`
+- `annotate_output_data_channels!(file)`
+
+The generated API listing above includes their full docstrings.

--- a/src/OWENS.jl
+++ b/src/OWENS.jl
@@ -73,6 +73,7 @@ include("core/utilities.jl")
 
 
 # Input/Output functionality
+include("io/result_channels.jl")
 include("io/fileio.jl")
 include("io/windio.jl")
 include("io/provenance.jl")

--- a/src/io/fileio.jl
+++ b/src/io/fileio.jl
@@ -1537,6 +1537,7 @@ function outputData(;
             HDF5.write(file, "topDamage_blade_L", topDamage_blade_L)
             HDF5.write(file, "topDamage_tower_U", topDamage_tower_U)
             HDF5.write(file, "topDamage_tower_L", topDamage_tower_L)
+            annotate_output_data_channels!(file)
         end
 
         if ofastformat

--- a/src/io/result_channels.jl
+++ b/src/io/result_channels.jl
@@ -1,0 +1,505 @@
+export ResultChannel,
+    output_data_channels,
+    output_data_channel,
+    output_data_channel_names,
+    annotate_output_data_channels!
+
+struct ResultChannel
+    name::String
+    units::String
+    dimensions::Vector{String}
+    frame::String
+    association::String
+    source::String
+    sign_convention::String
+    description::String
+end
+
+function ResultChannel(
+    name::AbstractString,
+    units::AbstractString,
+    dimensions::AbstractVector,
+    frame::AbstractString,
+    association::AbstractString,
+    source::AbstractString,
+    sign_convention::AbstractString,
+    description::AbstractString,
+)
+    return ResultChannel(
+        string(name),
+        string(units),
+        string.(collect(dimensions)),
+        string(frame),
+        string(association),
+        string(source),
+        string(sign_convention),
+        string(description),
+    )
+end
+
+const OUTPUT_DATA_CHANNELS = ResultChannel[
+    ResultChannel(
+        "t",
+        "s",
+        ["time"],
+        "scalar",
+        "time",
+        "OWENS runtime",
+        "positive elapsed simulation time",
+        "Simulation time at each saved state.",
+    ),
+    ResultChannel(
+        "aziHist",
+        "rad",
+        ["time"],
+        "rotor azimuth",
+        "rotor",
+        "OWENS runtime",
+        "positive in the OWENS rotor azimuth convention",
+        "Rotor azimuth history.",
+    ),
+    ResultChannel(
+        "OmegaHist",
+        "Hz",
+        ["time"],
+        "rotor",
+        "rotor",
+        "OWENS runtime",
+        "positive in the OWENS rotor-speed convention",
+        "Rotor rotational speed history.",
+    ),
+    ResultChannel(
+        "OmegaDotHist",
+        "Hz/s",
+        ["time"],
+        "rotor",
+        "rotor",
+        "OWENS runtime",
+        "positive in the OWENS rotor-acceleration convention",
+        "Rotor rotational acceleration history.",
+    ),
+    ResultChannel(
+        "gbHist",
+        "rad",
+        ["time"],
+        "drivetrain",
+        "gearbox",
+        "drivetrain model",
+        "positive in the gearbox azimuth convention",
+        "Gearbox azimuth history when the drivetrain model is active.",
+    ),
+    ResultChannel(
+        "gbDotHist",
+        "Hz",
+        ["time"],
+        "drivetrain",
+        "gearbox",
+        "drivetrain model",
+        "positive in the gearbox speed convention",
+        "Gearbox rotational speed history when the drivetrain model is active.",
+    ),
+    ResultChannel(
+        "gbDotDotHist",
+        "Hz/s",
+        ["time"],
+        "drivetrain",
+        "gearbox",
+        "drivetrain model",
+        "positive in the gearbox acceleration convention",
+        "Gearbox rotational acceleration history when the drivetrain model is active.",
+    ),
+    ResultChannel(
+        "FReactionHist",
+        "N or N*m by DOF",
+        ["time", "structural_dof"],
+        "structural mesh",
+        "node dof",
+        "OWENSFEA reactions",
+        "unknown",
+        "Reaction force and moment history grouped by six structural degrees of freedom per node.",
+    ),
+    ResultChannel(
+        "FTwrBsHist",
+        "N or N*m by DOF",
+        ["time", "tower_base_dof"],
+        "global",
+        "tower base",
+        "floating-platform coupling",
+        "unknown",
+        "Tower-base force and moment history.",
+    ),
+    ResultChannel(
+        "genTorque",
+        "N*m",
+        ["time"],
+        "drivetrain",
+        "generator",
+        "generator model",
+        "unknown",
+        "Generator torque history.",
+    ),
+    ResultChannel(
+        "genPower",
+        "W",
+        ["time"],
+        "drivetrain",
+        "generator",
+        "generator model",
+        "positive generator power convention",
+        "Generator power history.",
+    ),
+    ResultChannel(
+        "torqueDriveShaft",
+        "N*m",
+        ["time"],
+        "drivetrain",
+        "shaft",
+        "drivetrain model",
+        "unknown",
+        "Drive-shaft torque history.",
+    ),
+    ResultChannel(
+        "uHist",
+        "m or rad by DOF",
+        ["time", "structural_dof"],
+        "structural mesh",
+        "node dof",
+        "OWENSFEA displacement state",
+        "positive by structural DOF convention",
+        "Structural displacement and rotation history grouped by six degrees of freedom per node.",
+    ),
+    ResultChannel(
+        "uHist_prp",
+        "m or rad by DOF",
+        ["time", "platform_dof"],
+        "global",
+        "platform reference point",
+        "floating-platform coupling",
+        "positive by platform DOF convention",
+        "Platform-reference-point displacement and rotation history.",
+    ),
+    ResultChannel(
+        "epsilon_x_hist",
+        "strain",
+        ["quadrature_point", "element", "step"],
+        "beam element",
+        "element quadrature",
+        "OWENSFEA strain recovery",
+        "positive beam axial strain",
+        "Axial beam strain history.",
+    ),
+    ResultChannel(
+        "epsilon_y_hist",
+        "strain",
+        ["quadrature_point", "element", "step"],
+        "beam element",
+        "element quadrature",
+        "OWENSFEA strain recovery",
+        "positive local y shear/strain convention",
+        "Local y strain history.",
+    ),
+    ResultChannel(
+        "epsilon_z_hist",
+        "strain",
+        ["quadrature_point", "element", "step"],
+        "beam element",
+        "element quadrature",
+        "OWENSFEA strain recovery",
+        "positive local z shear/strain convention",
+        "Local z strain history.",
+    ),
+    ResultChannel(
+        "kappa_x_hist",
+        "1/m",
+        ["quadrature_point", "element", "step"],
+        "beam element",
+        "element quadrature",
+        "OWENSFEA curvature recovery",
+        "positive twist curvature convention",
+        "Beam twist curvature history.",
+    ),
+    ResultChannel(
+        "kappa_y_hist",
+        "1/m",
+        ["quadrature_point", "element", "step"],
+        "beam element",
+        "element quadrature",
+        "OWENSFEA curvature recovery",
+        "positive local y bending curvature convention",
+        "Beam local-y bending curvature history.",
+    ),
+    ResultChannel(
+        "kappa_z_hist",
+        "1/m",
+        ["quadrature_point", "element", "step"],
+        "beam element",
+        "element quadrature",
+        "OWENSFEA curvature recovery",
+        "positive local z bending curvature convention",
+        "Beam local-z bending curvature history.",
+    ),
+    ResultChannel(
+        "massOwens",
+        "kg",
+        String[],
+        "scalar",
+        "model",
+        "OWENS mass integration",
+        "positive mass",
+        "Integrated OWENS structural mass.",
+    ),
+    ResultChannel(
+        "stress_U",
+        "Pa",
+        ["time", "span_station", "chord_station", "stress_component"],
+        "composite material",
+        "blade upper laminate",
+        "composite stress recovery",
+        "unknown",
+        "Blade upper-laminate stress history.",
+    ),
+    ResultChannel(
+        "SF_ult_U",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "blade upper laminate",
+        "composite failure postprocessing",
+        "larger is safer",
+        "Blade upper-laminate ultimate safety-factor history.",
+    ),
+    ResultChannel(
+        "SF_buck_U",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "blade upper laminate",
+        "composite buckling postprocessing",
+        "larger is safer",
+        "Blade upper-laminate buckling safety-factor history.",
+    ),
+    ResultChannel(
+        "stress_L",
+        "Pa",
+        ["time", "span_station", "chord_station", "stress_component"],
+        "composite material",
+        "blade lower laminate",
+        "composite stress recovery",
+        "unknown",
+        "Blade lower-laminate stress history.",
+    ),
+    ResultChannel(
+        "SF_ult_L",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "blade lower laminate",
+        "composite failure postprocessing",
+        "larger is safer",
+        "Blade lower-laminate ultimate safety-factor history.",
+    ),
+    ResultChannel(
+        "SF_buck_L",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "blade lower laminate",
+        "composite buckling postprocessing",
+        "larger is safer",
+        "Blade lower-laminate buckling safety-factor history.",
+    ),
+    ResultChannel(
+        "stress_TU",
+        "Pa",
+        ["time", "span_station", "chord_station", "stress_component"],
+        "composite material",
+        "tower upper laminate",
+        "composite stress recovery",
+        "unknown",
+        "Tower upper-laminate stress history.",
+    ),
+    ResultChannel(
+        "SF_ult_TU",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "tower upper laminate",
+        "composite failure postprocessing",
+        "larger is safer",
+        "Tower upper-laminate ultimate safety-factor history.",
+    ),
+    ResultChannel(
+        "SF_buck_TU",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "tower upper laminate",
+        "composite buckling postprocessing",
+        "larger is safer",
+        "Tower upper-laminate buckling safety-factor history.",
+    ),
+    ResultChannel(
+        "stress_TL",
+        "Pa",
+        ["time", "span_station", "chord_station", "stress_component"],
+        "composite material",
+        "tower lower laminate",
+        "composite stress recovery",
+        "unknown",
+        "Tower lower-laminate stress history.",
+    ),
+    ResultChannel(
+        "SF_ult_TL",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "tower lower laminate",
+        "composite failure postprocessing",
+        "larger is safer",
+        "Tower lower-laminate ultimate safety-factor history.",
+    ),
+    ResultChannel(
+        "SF_buck_TL",
+        "dimensionless",
+        ["time", "span_station", "chord_station"],
+        "composite material",
+        "tower lower laminate",
+        "composite buckling postprocessing",
+        "larger is safer",
+        "Tower lower-laminate buckling safety-factor history.",
+    ),
+    ResultChannel(
+        "topstrainout_blade_U",
+        "mixed",
+        ["time", "span_station", "chord_station", "strain_component"],
+        "composite material",
+        "blade upper laminate",
+        "composite strain postprocessing",
+        "unknown",
+        "Blade upper-laminate top strain and beam strain/curvature channels.",
+    ),
+    ResultChannel(
+        "topstrainout_blade_L",
+        "mixed",
+        ["time", "span_station", "chord_station", "strain_component"],
+        "composite material",
+        "blade lower laminate",
+        "composite strain postprocessing",
+        "unknown",
+        "Blade lower-laminate top strain and beam strain/curvature channels.",
+    ),
+    ResultChannel(
+        "topstrainout_tower_U",
+        "mixed",
+        ["time", "span_station", "chord_station", "strain_component"],
+        "composite material",
+        "tower upper laminate",
+        "composite strain postprocessing",
+        "unknown",
+        "Tower upper-laminate top strain and beam strain/curvature channels.",
+    ),
+    ResultChannel(
+        "topstrainout_tower_L",
+        "mixed",
+        ["time", "span_station", "chord_station", "strain_component"],
+        "composite material",
+        "tower lower laminate",
+        "composite strain postprocessing",
+        "unknown",
+        "Tower lower-laminate top strain and beam strain/curvature channels.",
+    ),
+    ResultChannel(
+        "topDamage_blade_U",
+        "unknown",
+        ["span_station", "chord_station"],
+        "composite material",
+        "blade upper laminate",
+        "fatigue postprocessing",
+        "unknown",
+        "Blade upper-laminate fatigue-damage output.",
+    ),
+    ResultChannel(
+        "topDamage_blade_L",
+        "unknown",
+        ["span_station", "chord_station"],
+        "composite material",
+        "blade lower laminate",
+        "fatigue postprocessing",
+        "unknown",
+        "Blade lower-laminate fatigue-damage output.",
+    ),
+    ResultChannel(
+        "topDamage_tower_U",
+        "unknown",
+        ["span_station", "chord_station"],
+        "composite material",
+        "tower upper laminate",
+        "fatigue postprocessing",
+        "unknown",
+        "Tower upper-laminate fatigue-damage output.",
+    ),
+    ResultChannel(
+        "topDamage_tower_L",
+        "unknown",
+        ["span_station", "chord_station"],
+        "composite material",
+        "tower lower laminate",
+        "fatigue postprocessing",
+        "unknown",
+        "Tower lower-laminate fatigue-damage output.",
+    ),
+]
+
+const OUTPUT_DATA_CHANNEL_MAP = OrderedCollections.OrderedDict(
+    channel.name => channel for channel in OUTPUT_DATA_CHANNELS
+)
+
+"""
+    output_data_channels()
+
+Return metadata for each root-level dataset written by `outputData`.
+"""
+output_data_channels() = copy(OUTPUT_DATA_CHANNELS)
+
+"""
+    output_data_channel(name)
+
+Return the `ResultChannel` metadata for one `outputData` HDF5 dataset.
+"""
+function output_data_channel(name::AbstractString)
+    key = string(name)
+    haskey(OUTPUT_DATA_CHANNEL_MAP, key) ||
+        throw(KeyError("No outputData result channel is registered for $key"))
+    return OUTPUT_DATA_CHANNEL_MAP[key]
+end
+
+"""
+    output_data_channel_names()
+
+Return the dataset names written by `outputData` in writer order.
+"""
+output_data_channel_names() = [channel.name for channel in OUTPUT_DATA_CHANNELS]
+
+"""
+    annotate_output_data_channels!(file)
+
+Attach channel metadata attributes to any registered `outputData` datasets that
+are present in an open HDF5 file.
+"""
+function annotate_output_data_channels!(file)
+    for channel in OUTPUT_DATA_CHANNELS
+        if haskey(file, channel.name)
+            dataset_attrs = HDF5.attrs(file[channel.name])
+            dataset_attrs["owens_channel_name"] = channel.name
+            dataset_attrs["units"] = channel.units
+            dataset_attrs["dimensions"] = join(channel.dimensions, ",")
+            dataset_attrs["frame"] = channel.frame
+            dataset_attrs["association"] = channel.association
+            dataset_attrs["source"] = channel.source
+            dataset_attrs["sign_convention"] = channel.sign_convention
+            dataset_attrs["description"] = channel.description
+        end
+    end
+
+    return file
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,10 @@ end
     include("$path/test_run_manifest.jl")
 end
 
+@testset "Output Data Channels" begin
+    include("$path/test_output_data_channels.jl")
+end
+
 @testset "VTK History Output" begin
     include("$path/test_visualization_history.jl")
 end

--- a/test/test_output_data_channels.jl
+++ b/test/test_output_data_channels.jl
@@ -1,0 +1,164 @@
+using Test
+import HDF5
+import OWENS
+
+const OUTPUT_DATASET_NAMES = [
+    "t",
+    "aziHist",
+    "OmegaHist",
+    "OmegaDotHist",
+    "gbHist",
+    "gbDotHist",
+    "gbDotDotHist",
+    "FReactionHist",
+    "FTwrBsHist",
+    "genTorque",
+    "genPower",
+    "torqueDriveShaft",
+    "uHist",
+    "uHist_prp",
+    "epsilon_x_hist",
+    "epsilon_y_hist",
+    "epsilon_z_hist",
+    "kappa_x_hist",
+    "kappa_y_hist",
+    "kappa_z_hist",
+    "massOwens",
+    "stress_U",
+    "SF_ult_U",
+    "SF_buck_U",
+    "stress_L",
+    "SF_ult_L",
+    "SF_buck_L",
+    "stress_TU",
+    "SF_ult_TU",
+    "SF_buck_TU",
+    "stress_TL",
+    "SF_ult_TL",
+    "SF_buck_TL",
+    "topstrainout_blade_U",
+    "topstrainout_blade_L",
+    "topstrainout_tower_U",
+    "topstrainout_tower_L",
+    "topDamage_blade_U",
+    "topDamage_blade_L",
+    "topDamage_tower_U",
+    "topDamage_tower_L",
+]
+
+@testset "outputData channel registry" begin
+    channels = OWENS.output_data_channels()
+    @test channels isa Vector{OWENS.ResultChannel}
+    @test length(channels) == 41
+    @test OWENS.output_data_channel_names() == OUTPUT_DATASET_NAMES
+    @test [channel.name for channel in channels] == OUTPUT_DATASET_NAMES
+    @test length(unique(OWENS.output_data_channel_names())) == 41
+
+    time_channel = OWENS.output_data_channel("t")
+    @test time_channel.units == "s"
+    @test time_channel.dimensions == ["time"]
+    @test time_channel.frame == "scalar"
+    @test time_channel.association == "time"
+    @test time_channel.source == "OWENS runtime"
+    @test time_channel.sign_convention == "positive elapsed simulation time"
+
+    reaction_channel = OWENS.output_data_channel("FReactionHist")
+    @test reaction_channel.units == "N or N*m by DOF"
+    @test reaction_channel.dimensions == ["time", "structural_dof"]
+    @test reaction_channel.frame == "structural mesh"
+    @test reaction_channel.sign_convention == "unknown"
+
+    stress_channel = OWENS.output_data_channel("stress_U")
+    @test stress_channel.units == "Pa"
+    @test stress_channel.dimensions == ["time", "span_station", "chord_station", "stress_component"]
+    @test stress_channel.association == "blade upper laminate"
+
+    @test_throws KeyError OWENS.output_data_channel("not_a_channel")
+end
+
+@testset "outputData writes channel metadata" begin
+    mktempdir() do dir
+        data_output = joinpath(dir, "unit.out")
+        inputs = (; dataOutputFilename = data_output)
+
+        vector = [1.0, 2.0, 3.0]
+        dof_history = reshape(collect(1.0:18.0), 3, 6)
+        strain_history = reshape(collect(1.0:24.0), 4, 2, 3)
+        stress_history = reshape(collect(1.0:72.0), 3, 2, 4, 3)
+        safety_factor = reshape(collect(1.0:24.0), 3, 2, 4)
+        topstrain = reshape(collect(1.0:216.0), 3, 2, 4, 9)
+        damage = reshape(collect(1.0:8.0), 2, 4)
+
+        OWENS.outputData(;
+            inputs,
+            t=vector,
+            aziHist=vector .+ 0.1,
+            OmegaHist=vector .+ 0.2,
+            OmegaDotHist=vector .+ 0.3,
+            gbHist=vector .+ 0.4,
+            gbDotHist=vector .+ 0.5,
+            gbDotDotHist=vector .+ 0.6,
+            FReactionHist=dof_history,
+            FTwrBsHist=dof_history .+ 10.0,
+            genTorque=vector .+ 0.7,
+            genPower=vector .+ 0.8,
+            torqueDriveShaft=vector .+ 0.9,
+            uHist=dof_history .+ 20.0,
+            uHist_prp=dof_history .+ 30.0,
+            epsilon_x_hist=strain_history .+ 1.0,
+            epsilon_y_hist=strain_history .+ 2.0,
+            epsilon_z_hist=strain_history .+ 3.0,
+            kappa_x_hist=strain_history .+ 4.0,
+            kappa_y_hist=strain_history .+ 5.0,
+            kappa_z_hist=strain_history .+ 6.0,
+            massOwens=12.5,
+            stress_U=stress_history .+ 1.0,
+            SF_ult_U=safety_factor .+ 1.0,
+            SF_buck_U=safety_factor .+ 2.0,
+            stress_L=stress_history .+ 2.0,
+            SF_ult_L=safety_factor .+ 3.0,
+            SF_buck_L=safety_factor .+ 4.0,
+            stress_TU=stress_history .+ 3.0,
+            SF_ult_TU=safety_factor .+ 5.0,
+            SF_buck_TU=safety_factor .+ 6.0,
+            stress_TL=stress_history .+ 4.0,
+            SF_ult_TL=safety_factor .+ 7.0,
+            SF_buck_TL=safety_factor .+ 8.0,
+            topstrainout_blade_U=topstrain .+ 1.0,
+            topstrainout_blade_L=topstrain .+ 2.0,
+            topstrainout_tower_U=topstrain .+ 3.0,
+            topstrainout_tower_L=topstrain .+ 4.0,
+            topDamage_blade_U=damage .+ 1.0,
+            topDamage_blade_L=damage .+ 2.0,
+            topDamage_tower_U=damage .+ 3.0,
+            topDamage_tower_L=damage .+ 4.0,
+        )
+
+        h5_file = joinpath(dir, "unit.h5")
+        @test isfile(h5_file)
+
+        HDF5.h5open(h5_file, "r") do file
+            @test sort(keys(file)) == sort(OUTPUT_DATASET_NAMES)
+            @test HDF5.read(file["t"]) == vector
+            @test HDF5.read(file["massOwens"]) == 12.5
+            @test size(HDF5.read(file["FReactionHist"])) == (3, 6)
+            @test size(HDF5.read(file["epsilon_x_hist"])) == (4, 2, 3)
+            @test size(HDF5.read(file["stress_U"])) == (3, 2, 4, 3)
+            @test size(HDF5.read(file["topstrainout_blade_U"])) == (3, 2, 4, 9)
+            @test size(HDF5.read(file["topDamage_blade_U"])) == (2, 4)
+
+            for name in OUTPUT_DATASET_NAMES
+                channel = OWENS.output_data_channel(name)
+                attrs = HDF5.attrs(file[name])
+                @test attrs["owens_channel_name"] == name
+                @test attrs["units"] == channel.units
+                @test attrs["dimensions"] == join(channel.dimensions, ",")
+                @test attrs["frame"] == channel.frame
+                @test attrs["association"] == channel.association
+                @test attrs["source"] == channel.source
+                @test attrs["sign_convention"] == channel.sign_convention
+                @test attrs["description"] == channel.description
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add a typed registry for every root-level HDF5 dataset written by outputData
- annotate outputData HDF5 datasets with units, dimensions, frame, source, association, and sign-convention metadata
- add a real tiny HDF5 outputData fixture test that verifies all 41 datasets and attributes
- document the output channel helpers in the OWENS reference page

## Stack
Depends on #140 / codex/run-provenance-manifest.

## Tests
- julia --project=. test/test_output_data_channels.jl
- julia --project=. -e 'path=joinpath(pwd(), "test"); using Test; @testset "Run Manifest Provenance" begin include(joinpath(path, "test_run_manifest.jl")) end; @testset "Output Data Channels" begin include(joinpath(path, "test_output_data_channels.jl")) end; @testset "VTK History Output" begin include(joinpath(path, "test_visualization_history.jl")) end'
- git diff --check
- julia -e 'using JuliaFormatter; println(format_file("src/io/result_channels.jl"; overwrite=false, verbose=true)); println(format_file("src/io/fileio.jl"; overwrite=false, verbose=true)); println(format_file("src/OWENS.jl"; overwrite=false, verbose=true))'