### PR TITLE
Add output data summary helper

### DIFF
--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -21,6 +21,11 @@ with channel metadata. Use `output_data_channels()` when postprocessing tools,
 validation dashboards, or GUI code need stable units and axis labels without
 hard-coding dataset positions.
 
+Use `output_data_summary(path)` to inspect which registered channels are
+present in an HDF5 result file, including shape, element type, units, and
+metadata-attribute mismatches, without reading the full result arrays. This is
+the preferred entry point for GUI channel pickers and validation dashboards.
+
 The public helpers are:
 
 - `ResultChannel`
@@ -28,6 +33,7 @@ The public helpers are:
 - `output_data_channel(name)`
 - `output_data_channel_names()`
 - `annotate_output_data_channels!(file)`
+- `output_data_summary(path)`
 - `WindIORunSpec`
 - `windio_run_spec(modeling_options_file, windio_file, run_path)`
 - `render_windio_run_script(spec)`

--- a/src/io/result_channels.jl
+++ b/src/io/result_channels.jl
@@ -2,7 +2,8 @@ export ResultChannel,
     output_data_channels,
     output_data_channel,
     output_data_channel_names,
-    annotate_output_data_channels!
+    annotate_output_data_channels!,
+    output_data_summary
 
 struct ResultChannel
     name::String
@@ -502,4 +503,155 @@ function annotate_output_data_channels!(file)
     end
 
     return file
+end
+
+"""
+    output_data_summary(path; channels=output_data_channel_names(), include_unregistered=false)
+
+Inspect an OWENS `outputData` HDF5 file and return one summary row per
+requested registered channel. Missing registered channels are returned with
+`present=false`; root-level unregistered datasets are appended only when
+`include_unregistered=true`. The helper reads dataset headers and attributes,
+not full dataset contents.
+"""
+function output_data_summary(
+    path::AbstractString;
+    channels = output_data_channel_names(),
+    include_unregistered::Bool = false,
+)
+    isfile(path) || throw(ArgumentError("Cannot summarize missing output file: $path"))
+
+    requested_channels = _output_summary_channels(channels)
+    for name in requested_channels
+        haskey(OUTPUT_DATA_CHANNEL_MAP, name) ||
+            throw(KeyError("No outputData result channel is registered for $name"))
+    end
+
+    HDF5.h5open(path, "r") do file
+        summaries = [_registered_output_summary(file, name) for name in requested_channels]
+        if include_unregistered
+            registered_names = output_data_channel_names()
+            extras = sort(setdiff(_root_dataset_names(file), registered_names))
+            return vcat(
+                summaries,
+                [_unregistered_output_summary(file, name) for name in extras],
+            )
+        end
+
+        return summaries
+    end
+end
+
+_root_dataset_names(file) =
+    String[name for name in keys(file) if file[name] isa HDF5.Dataset]
+
+_output_summary_channels(channels::AbstractString) = [String(channels)]
+_output_summary_channels(channels) = String.(collect(channels))
+
+function _registered_output_summary(file, name::AbstractString)
+    channel = output_data_channel(name)
+    if !haskey(file, name) || !(file[name] isa HDF5.Dataset)
+        return _output_summary_row(
+            channel;
+            present = false,
+            shape = missing,
+            ndims = missing,
+            eltype = missing,
+            has_channel_attrs = false,
+            attr_mismatches = String[],
+        )
+    end
+
+    dataset = file[name]
+    dataset_attrs = HDF5.attrs(dataset)
+    return _output_summary_row(
+        channel;
+        present = true,
+        shape = collect(Int, size(dataset)),
+        ndims = length(size(dataset)),
+        eltype = string(eltype(dataset)),
+        has_channel_attrs = _has_channel_attrs(dataset_attrs),
+        attr_mismatches = _channel_attr_mismatches(dataset_attrs, channel),
+    )
+end
+
+function _unregistered_output_summary(file, name::AbstractString)
+    dataset = file[name]
+    return (
+        name = string(name),
+        present = true,
+        registered = false,
+        shape = collect(Int, size(dataset)),
+        ndims = length(size(dataset)),
+        eltype = string(eltype(dataset)),
+        units = missing,
+        dimensions = missing,
+        frame = missing,
+        association = missing,
+        source = missing,
+        sign_convention = missing,
+        description = missing,
+        has_channel_attrs = false,
+        attr_mismatches = String[],
+    )
+end
+
+function _output_summary_row(
+    channel::ResultChannel;
+    present,
+    shape,
+    ndims,
+    eltype,
+    has_channel_attrs::Bool,
+    attr_mismatches::Vector{String},
+)
+    return (
+        name = channel.name,
+        present,
+        registered = true,
+        shape,
+        ndims,
+        eltype,
+        units = channel.units,
+        dimensions = copy(channel.dimensions),
+        frame = channel.frame,
+        association = channel.association,
+        source = channel.source,
+        sign_convention = channel.sign_convention,
+        description = channel.description,
+        has_channel_attrs,
+        attr_mismatches,
+    )
+end
+
+const OUTPUT_DATA_CHANNEL_ATTRS = OrderedCollections.OrderedDict{String,Function}(
+    "owens_channel_name" => channel -> channel.name,
+    "units" => channel -> channel.units,
+    "dimensions" => channel -> join(channel.dimensions, ","),
+    "frame" => channel -> channel.frame,
+    "association" => channel -> channel.association,
+    "source" => channel -> channel.source,
+    "sign_convention" => channel -> channel.sign_convention,
+    "description" => channel -> channel.description,
+)
+
+function _has_channel_attrs(dataset_attrs)
+    return all(haskey(dataset_attrs, key) for key in keys(OUTPUT_DATA_CHANNEL_ATTRS))
+end
+
+function _channel_attr_mismatches(dataset_attrs, channel::ResultChannel)
+    mismatches = String[]
+    for (key, expected_func) in OUTPUT_DATA_CHANNEL_ATTRS
+        expected = expected_func(channel)
+        if !haskey(dataset_attrs, key)
+            push!(mismatches, "missing:$key")
+        elseif dataset_attrs[key] != expected
+            push!(
+                mismatches,
+                "$key: expected $(repr(expected)), got $(repr(dataset_attrs[key]))",
+            )
+        end
+    end
+
+    return mismatches
 end

--- a/test/test_output_data_channels.jl
+++ b/test/test_output_data_channels.jl
@@ -162,3 +162,138 @@ end
         end
     end
 end
+
+@testset "outputData summary" begin
+    mktempdir() do dir
+        data_output = joinpath(dir, "unit.out")
+        inputs = (; dataOutputFilename = data_output)
+
+        vector = [1.0, 2.0, 3.0]
+        dof_history = reshape(collect(1.0:18.0), 3, 6)
+        strain_history = reshape(collect(1.0:24.0), 4, 2, 3)
+        stress_history = reshape(collect(1.0:72.0), 3, 2, 4, 3)
+        safety_factor = reshape(collect(1.0:24.0), 3, 2, 4)
+        topstrain = reshape(collect(1.0:216.0), 3, 2, 4, 9)
+        damage = reshape(collect(1.0:8.0), 2, 4)
+
+        OWENS.outputData(;
+            inputs,
+            t=vector,
+            aziHist=vector .+ 0.1,
+            OmegaHist=vector .+ 0.2,
+            OmegaDotHist=vector .+ 0.3,
+            gbHist=vector .+ 0.4,
+            gbDotHist=vector .+ 0.5,
+            gbDotDotHist=vector .+ 0.6,
+            FReactionHist=dof_history,
+            FTwrBsHist=dof_history .+ 10.0,
+            genTorque=vector .+ 0.7,
+            genPower=vector .+ 0.8,
+            torqueDriveShaft=vector .+ 0.9,
+            uHist=dof_history .+ 20.0,
+            uHist_prp=dof_history .+ 30.0,
+            epsilon_x_hist=strain_history .+ 1.0,
+            epsilon_y_hist=strain_history .+ 2.0,
+            epsilon_z_hist=strain_history .+ 3.0,
+            kappa_x_hist=strain_history .+ 4.0,
+            kappa_y_hist=strain_history .+ 5.0,
+            kappa_z_hist=strain_history .+ 6.0,
+            massOwens=12.5,
+            stress_U=stress_history .+ 1.0,
+            SF_ult_U=safety_factor .+ 1.0,
+            SF_buck_U=safety_factor .+ 2.0,
+            stress_L=stress_history .+ 2.0,
+            SF_ult_L=safety_factor .+ 3.0,
+            SF_buck_L=safety_factor .+ 4.0,
+            stress_TU=stress_history .+ 3.0,
+            SF_ult_TU=safety_factor .+ 5.0,
+            SF_buck_TU=safety_factor .+ 6.0,
+            stress_TL=stress_history .+ 4.0,
+            SF_ult_TL=safety_factor .+ 7.0,
+            SF_buck_TL=safety_factor .+ 8.0,
+            topstrainout_blade_U=topstrain .+ 1.0,
+            topstrainout_blade_L=topstrain .+ 2.0,
+            topstrainout_tower_U=topstrain .+ 3.0,
+            topstrainout_tower_L=topstrain .+ 4.0,
+            topDamage_blade_U=damage .+ 1.0,
+            topDamage_blade_L=damage .+ 2.0,
+            topDamage_tower_U=damage .+ 3.0,
+            topDamage_tower_L=damage .+ 4.0,
+        )
+
+        h5_file = joinpath(dir, "unit.h5")
+        summary = OWENS.output_data_summary(h5_file)
+        @test length(summary) == 41
+        @test [row.name for row in summary] == OUTPUT_DATASET_NAMES
+        @test all(row.present for row in summary)
+        @test all(row.registered for row in summary)
+        @test all(row.has_channel_attrs for row in summary)
+        @test all(isempty(row.attr_mismatches) for row in summary)
+        @test summary[1].name == "t"
+        @test summary[1].shape == [3]
+        @test summary[1].ndims == 1
+        @test summary[1].eltype == "Float64"
+        @test summary[1].units == "s"
+        @test summary[1].dimensions == ["time"]
+        @test summary[8].name == "FReactionHist"
+        @test summary[8].shape == [3, 6]
+        @test summary[8].units == "N or N*m by DOF"
+        @test summary[21].name == "massOwens"
+        @test summary[21].shape == Int[]
+        @test summary[21].ndims == 0
+        @test summary[22].name == "stress_U"
+        @test summary[22].shape == [3, 2, 4, 3]
+
+        partial_file = joinpath(dir, "partial.h5")
+        HDF5.h5open(partial_file, "w") do file
+            HDF5.write(file, "t", vector)
+            HDF5.write(file, "custom_channel", [4.0, 5.0])
+        end
+
+        partial_summary = OWENS.output_data_summary(partial_file)
+        @test length(partial_summary) == 41
+        @test partial_summary[1].name == "t"
+        @test partial_summary[1].present === true
+        @test partial_summary[1].shape == [3]
+        @test partial_summary[1].has_channel_attrs === false
+        @test partial_summary[1].attr_mismatches == [
+            "missing:owens_channel_name",
+            "missing:units",
+            "missing:dimensions",
+            "missing:frame",
+            "missing:association",
+            "missing:source",
+            "missing:sign_convention",
+            "missing:description",
+        ]
+        @test partial_summary[2].name == "aziHist"
+        @test partial_summary[2].present === false
+        @test ismissing(partial_summary[2].shape)
+        @test ismissing(partial_summary[2].ndims)
+        @test ismissing(partial_summary[2].eltype)
+        @test partial_summary[2].units == "rad"
+        @test partial_summary[2].dimensions == ["time"]
+
+        with_extra = OWENS.output_data_summary(partial_file; include_unregistered = true)
+        @test length(with_extra) == 42
+        @test with_extra[end].name == "custom_channel"
+        @test with_extra[end].present === true
+        @test with_extra[end].registered === false
+        @test with_extra[end].shape == [2]
+        @test with_extra[end].eltype == "Float64"
+        @test ismissing(with_extra[end].units)
+        @test ismissing(with_extra[end].dimensions)
+
+        t_only = OWENS.output_data_summary(partial_file; channels = ["t"])
+        @test length(t_only) == 1
+        @test t_only[1].name == "t"
+        @test t_only[1].present === true
+        @test OWENS.output_data_summary(partial_file; channels = "t") == t_only
+
+        @test_throws KeyError OWENS.output_data_summary(
+            partial_file;
+            channels = ["not_a_channel"],
+        )
+        @test_throws ArgumentError OWENS.output_data_summary(joinpath(dir, "missing.h5"))
+    end
+end


### PR DESCRIPTION
Adds output_data_summary for HDF5 outputData files. It reports registered channel presence, shape, element type, metadata fields, and attribute mismatches without reading full arrays. Depends on PR 142. Tests: output data channel tests, recent cheap unit block, formatter on result_channels, and git diff check.