### PR TITLE
Add WindIO manifest helpers

### DIFF
--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -38,5 +38,7 @@ The public helpers are:
 - `windio_run_spec(modeling_options_file, windio_file, run_path)`
 - `render_windio_run_script(spec)`
 - `write_windio_run_script(path, spec)`
+- `build_windio_run_manifest(spec)`
+- `write_windio_run_manifest(path, spec)`
 
 The generated API listing above includes their full docstrings.

--- a/src/io/windio_run_spec.jl
+++ b/src/io/windio_run_spec.jl
@@ -1,4 +1,9 @@
-export WindIORunSpec, windio_run_spec, render_windio_run_script, write_windio_run_script
+export WindIORunSpec,
+    windio_run_spec,
+    render_windio_run_script,
+    write_windio_run_script,
+    build_windio_run_manifest,
+    write_windio_run_manifest
 
 struct WindIORunSpec
     modeling_options_file::String
@@ -79,6 +84,53 @@ function write_windio_run_script(path::AbstractString, spec::WindIORunSpec)
     end
 
     return script
+end
+
+"""
+    build_windio_run_manifest(spec; kwargs...)
+
+Build a run manifest for a `WindIORunSpec`, hashing the modeling-options and
+WindIO input files plus any existing output/generated files passed through
+`output_files` or `generated_files`.
+"""
+function build_windio_run_manifest(
+    spec::WindIORunSpec;
+    run_id = nothing,
+    run_name::AbstractString = "windio-run",
+    output_files = String[],
+    generated_files = String[],
+    parameters = OrderedCollections.OrderedDict{String,Any}(),
+    metadata = OrderedCollections.OrderedDict{String,Any}(),
+    warnings = String[],
+    status::AbstractString = "created",
+    created_at_utc = nothing,
+)
+    return build_run_manifest(;
+        run_id,
+        run_name,
+        project_root = spec.run_path,
+        solver = "runOWENSWINDIO",
+        modeling_options_file = spec.modeling_options_file,
+        windio_file = spec.windio_file,
+        output_files,
+        generated_files,
+        parameters,
+        metadata,
+        warnings,
+        status,
+        created_at_utc,
+    )
+end
+
+"""
+    write_windio_run_manifest(path, spec; kwargs...)
+
+Build and write a WindIO run manifest. Returns the manifest that was written.
+"""
+function write_windio_run_manifest(path::AbstractString, spec::WindIORunSpec; kwargs...)
+    manifest = build_windio_run_manifest(spec; kwargs...)
+    write_run_manifest(path, manifest)
+    return manifest
 end
 
 _julia_string_literal(value::AbstractString) = repr(String(value))

--- a/test/test_windio_run_spec.jl
+++ b/test/test_windio_run_spec.jl
@@ -1,6 +1,10 @@
 using Test
 import OWENS
 
+const WINDIO_SPEC_MODEL_SHA256 = "5fdc1fb3c0b14924ab13cbe75816f20ada7685ccb6ad4ca8a5103251233ddaf0"
+const WINDIO_SPEC_DESIGN_SHA256 = "8c6ed05c7c0f22c45fc5acea73c206ab9ca0b1b7d62b7fbb6b246cb3f080e496"
+const WINDIO_SPEC_OUTPUT_SHA256 = "a02b48c12e33e850387f1890f7aaa11c845f5d62f783919978585d2d52c9c7aa"
+
 @testset "WindIO run spec paths" begin
     mktempdir() do dir
         model_file = joinpath(dir, "modeling_options.yml")
@@ -41,6 +45,73 @@ import OWENS
             windio_file,
             joinpath(dir, "missing_run"),
         )
+    end
+end
+
+@testset "WindIO run manifest export" begin
+    mktempdir() do dir
+        model_file = joinpath(dir, "modeling_options.yml")
+        windio_file = joinpath(dir, "design.yml")
+        run_path = joinpath(dir, "run")
+        output_file = joinpath(run_path, "output.h5")
+        manifest_file = joinpath(run_path, "run_manifest.yml")
+        write(model_file, "OWENS_Options:\n  numTS: 2\n")
+        write(windio_file, "name: unit\n")
+        mkdir(run_path)
+        write(output_file, "output: done\n")
+
+        spec = OWENS.windio_run_spec(model_file, windio_file, run_path)
+        manifest = OWENS.build_windio_run_manifest(
+            spec;
+            run_id = "windio-unit-001",
+            run_name = "windio unit",
+            output_files = [output_file],
+            parameters = Dict(:case => "manifest"),
+            metadata = Dict(:source => "test"),
+            warnings = ["unit warning"],
+            status = "complete",
+            created_at_utc = "2026-05-20T00:00:00.000Z",
+        )
+
+        @test manifest["schema_version"] == "owens-run-manifest/v1"
+        @test manifest["run_id"] == "windio-unit-001"
+        @test manifest["run_name"] == "windio unit"
+        @test manifest["solver"] == "runOWENSWINDIO"
+        @test manifest["project_root"] == abspath(run_path)
+        @test manifest["status"] == "complete"
+        @test manifest["created_at_utc"] == "2026-05-20T00:00:00.000Z"
+        @test manifest["parameters"]["case"] == "manifest"
+        @test manifest["metadata"]["source"] == "test"
+        @test manifest["warnings"] == ["unit warning"]
+
+        @test length(manifest["inputs"]) == 2
+        @test manifest["inputs"][1]["path"] ==
+              relpath(abspath(model_file), abspath(run_path))
+        @test manifest["inputs"][1]["role"] == "modeling_options"
+        @test manifest["inputs"][1]["sha256"] == WINDIO_SPEC_MODEL_SHA256
+        @test manifest["inputs"][2]["path"] ==
+              relpath(abspath(windio_file), abspath(run_path))
+        @test manifest["inputs"][2]["role"] == "windio"
+        @test manifest["inputs"][2]["sha256"] == WINDIO_SPEC_DESIGN_SHA256
+
+        @test length(manifest["outputs"]) == 1
+        @test manifest["outputs"][1]["path"] == "output.h5"
+        @test manifest["outputs"][1]["role"] == "output"
+        @test manifest["outputs"][1]["sha256"] == WINDIO_SPEC_OUTPUT_SHA256
+
+        written = OWENS.write_windio_run_manifest(
+            manifest_file,
+            spec;
+            run_id = "windio-unit-002",
+            output_files = [output_file],
+            created_at_utc = "2026-05-20T00:00:00.000Z",
+        )
+        loaded = OWENS.read_run_manifest(manifest_file)
+        @test written["run_id"] == "windio-unit-002"
+        @test loaded["run_id"] == "windio-unit-002"
+        @test loaded["inputs"][1]["sha256"] == WINDIO_SPEC_MODEL_SHA256
+        @test loaded["inputs"][2]["sha256"] == WINDIO_SPEC_DESIGN_SHA256
+        @test loaded["outputs"][1]["sha256"] == WINDIO_SPEC_OUTPUT_SHA256
     end
 end
 


### PR DESCRIPTION
Adds build and write helpers that connect WindIORunSpec to the OWENS run manifest/provenance layer. Depends on PR 143. Tests: WindIO run spec tests, recent cheap unit block, formatter on windio_run_spec and test file, and git diff check.