### PR TITLE
Add output data channel metrics

### DIFF
--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -26,6 +26,11 @@ present in an HDF5 result file, including shape, element type, units, and
 metadata-attribute mismatches, without reading the full result arrays. This is
 the preferred entry point for GUI channel pickers and validation dashboards.
 
+Use `output_data_channel_metrics(reference_path, candidate_path; channels, atol,
+rtol)` to compare selected numeric channels from two result files. It reports
+bias, RMSE, maximum absolute error, mean absolute error, reference RMS, relative
+RMSE, and a pass/fail result using `atol + rtol * max_abs_reference`.
+
 The public helpers are:
 
 - `ResultChannel`
@@ -34,6 +39,7 @@ The public helpers are:
 - `output_data_channel_names()`
 - `annotate_output_data_channels!(file)`
 - `output_data_summary(path)`
+- `output_data_channel_metrics(reference_path, candidate_path)`
 - `WindIORunSpec`
 - `windio_run_spec(modeling_options_file, windio_file, run_path)`
 - `render_windio_run_script(spec)`

--- a/src/io/result_channels.jl
+++ b/src/io/result_channels.jl
@@ -3,7 +3,8 @@ export ResultChannel,
     output_data_channel,
     output_data_channel_names,
     annotate_output_data_channels!,
-    output_data_summary
+    output_data_summary,
+    output_data_channel_metrics
 
 struct ResultChannel
     name::String
@@ -654,4 +655,184 @@ function _channel_attr_mismatches(dataset_attrs, channel::ResultChannel)
     end
 
     return mismatches
+end
+
+"""
+    output_data_channel_metrics(reference_path, candidate_path; channels, atol=0.0, rtol=1e-6)
+
+Compare selected numeric channels from two OWENS `outputData` HDF5 files. The
+function reads only the requested datasets and returns per-channel bias, RMSE,
+maximum absolute error, mean absolute error, reference RMS, and relative RMSE.
+Missing, shape-mismatched, or non-numeric channels are returned as
+`comparable=false` rows with an explanatory `status`.
+
+A comparable channel passes when `max_abs_error <= atol + rtol * max_abs_reference`.
+"""
+function output_data_channel_metrics(
+    reference_path::AbstractString,
+    candidate_path::AbstractString;
+    channels = output_data_channel_names(),
+    atol::Real = 0.0,
+    rtol::Real = 1e-6,
+)
+    isfile(reference_path) ||
+        throw(ArgumentError("Cannot compare missing reference file: $reference_path"))
+    isfile(candidate_path) ||
+        throw(ArgumentError("Cannot compare missing candidate file: $candidate_path"))
+    atol >= 0 || throw(ArgumentError("atol must be non-negative, got $atol"))
+    rtol >= 0 || throw(ArgumentError("rtol must be non-negative, got $rtol"))
+
+    requested_channels = _output_summary_channels(channels)
+    for name in requested_channels
+        haskey(OUTPUT_DATA_CHANNEL_MAP, name) ||
+            throw(KeyError("No outputData result channel is registered for $name"))
+    end
+
+    HDF5.h5open(reference_path, "r") do reference_file
+        HDF5.h5open(candidate_path, "r") do candidate_file
+            return [
+                _output_channel_metric(reference_file, candidate_file, name, atol, rtol) for
+                name in requested_channels
+            ]
+        end
+    end
+end
+
+function _output_channel_metric(
+    reference_file,
+    candidate_file,
+    name::AbstractString,
+    atol::Real,
+    rtol::Real,
+)
+    channel = output_data_channel(name)
+    reference_present =
+        haskey(reference_file, name) && reference_file[name] isa HDF5.Dataset
+    candidate_present =
+        haskey(candidate_file, name) && candidate_file[name] isa HDF5.Dataset
+
+    if !reference_present && !candidate_present
+        return _noncomparable_metric_row(channel, "missing_reference_and_candidate")
+    elseif !reference_present
+        return _noncomparable_metric_row(
+            channel,
+            "missing_reference";
+            candidate_shape = collect(Int, size(candidate_file[name])),
+        )
+    elseif !candidate_present
+        return _noncomparable_metric_row(
+            channel,
+            "missing_candidate";
+            reference_shape = collect(Int, size(reference_file[name])),
+        )
+    end
+
+    reference_shape = collect(Int, size(reference_file[name]))
+    candidate_shape = collect(Int, size(candidate_file[name]))
+    if reference_shape != candidate_shape
+        return _noncomparable_metric_row(
+            channel,
+            "shape_mismatch";
+            reference_shape,
+            candidate_shape,
+        )
+    end
+
+    reference_data = HDF5.read(reference_file[name])
+    candidate_data = HDF5.read(candidate_file[name])
+    if !_is_real_output_data(reference_data) || !_is_real_output_data(candidate_data)
+        return _noncomparable_metric_row(
+            channel,
+            "non_numeric";
+            reference_shape,
+            candidate_shape,
+        )
+    end
+
+    reference_values = _real_output_values(reference_data)
+    candidate_values = _real_output_values(candidate_data)
+    if isempty(reference_values)
+        return _noncomparable_metric_row(channel, "empty"; reference_shape, candidate_shape)
+    end
+
+    if !all(isfinite, reference_values) || !all(isfinite, candidate_values)
+        return _noncomparable_metric_row(
+            channel,
+            "non_finite";
+            reference_shape,
+            candidate_shape,
+        )
+    end
+
+    difference = candidate_values .- reference_values
+    abs_difference = abs.(difference)
+    n = length(difference)
+    bias = sum(difference) / n
+    rmse = sqrt(sum(abs2, difference) / n)
+    max_abs_error = maximum(abs_difference)
+    mean_abs_error = sum(abs_difference) / n
+    reference_rms = sqrt(sum(abs2, reference_values) / n)
+    max_abs_reference = maximum(abs.(reference_values))
+    relative_rmse = _relative_error(rmse, reference_rms)
+    tolerance = Float64(atol) + Float64(rtol) * max_abs_reference
+    passed = max_abs_error <= tolerance
+
+    return (
+        name = channel.name,
+        comparable = true,
+        passed,
+        status = passed ? "pass" : "fail",
+        units = channel.units,
+        dimensions = copy(channel.dimensions),
+        reference_shape,
+        candidate_shape,
+        n,
+        bias,
+        rmse,
+        max_abs_error,
+        mean_abs_error,
+        reference_rms,
+        max_abs_reference,
+        relative_rmse,
+        tolerance,
+    )
+end
+
+function _noncomparable_metric_row(
+    channel::ResultChannel,
+    status::AbstractString;
+    reference_shape = missing,
+    candidate_shape = missing,
+)
+    return (
+        name = channel.name,
+        comparable = false,
+        passed = false,
+        status = string(status),
+        units = channel.units,
+        dimensions = copy(channel.dimensions),
+        reference_shape,
+        candidate_shape,
+        n = 0,
+        bias = missing,
+        rmse = missing,
+        max_abs_error = missing,
+        mean_abs_error = missing,
+        reference_rms = missing,
+        max_abs_reference = missing,
+        relative_rmse = missing,
+        tolerance = missing,
+    )
+end
+
+_is_real_output_data(value) = value isa Real || value isa AbstractArray{<:Real}
+_real_output_values(value::Real) = [Float64(value)]
+_real_output_values(value::AbstractArray{<:Real}) = Float64.(vec(value))
+
+function _relative_error(error::Real, scale::Real)
+    if scale == 0
+        return error == 0 ? 0.0 : Inf
+    end
+
+    return error / scale
 end

--- a/test/test_output_data_channels.jl
+++ b/test/test_output_data_channels.jl
@@ -70,7 +70,8 @@ const OUTPUT_DATASET_NAMES = [
 
     stress_channel = OWENS.output_data_channel("stress_U")
     @test stress_channel.units == "Pa"
-    @test stress_channel.dimensions == ["time", "span_station", "chord_station", "stress_component"]
+    @test stress_channel.dimensions ==
+          ["time", "span_station", "chord_station", "stress_component"]
     @test stress_channel.association == "blade upper laminate"
 
     @test_throws KeyError OWENS.output_data_channel("not_a_channel")
@@ -91,47 +92,47 @@ end
 
         OWENS.outputData(;
             inputs,
-            t=vector,
-            aziHist=vector .+ 0.1,
-            OmegaHist=vector .+ 0.2,
-            OmegaDotHist=vector .+ 0.3,
-            gbHist=vector .+ 0.4,
-            gbDotHist=vector .+ 0.5,
-            gbDotDotHist=vector .+ 0.6,
-            FReactionHist=dof_history,
-            FTwrBsHist=dof_history .+ 10.0,
-            genTorque=vector .+ 0.7,
-            genPower=vector .+ 0.8,
-            torqueDriveShaft=vector .+ 0.9,
-            uHist=dof_history .+ 20.0,
-            uHist_prp=dof_history .+ 30.0,
-            epsilon_x_hist=strain_history .+ 1.0,
-            epsilon_y_hist=strain_history .+ 2.0,
-            epsilon_z_hist=strain_history .+ 3.0,
-            kappa_x_hist=strain_history .+ 4.0,
-            kappa_y_hist=strain_history .+ 5.0,
-            kappa_z_hist=strain_history .+ 6.0,
-            massOwens=12.5,
-            stress_U=stress_history .+ 1.0,
-            SF_ult_U=safety_factor .+ 1.0,
-            SF_buck_U=safety_factor .+ 2.0,
-            stress_L=stress_history .+ 2.0,
-            SF_ult_L=safety_factor .+ 3.0,
-            SF_buck_L=safety_factor .+ 4.0,
-            stress_TU=stress_history .+ 3.0,
-            SF_ult_TU=safety_factor .+ 5.0,
-            SF_buck_TU=safety_factor .+ 6.0,
-            stress_TL=stress_history .+ 4.0,
-            SF_ult_TL=safety_factor .+ 7.0,
-            SF_buck_TL=safety_factor .+ 8.0,
-            topstrainout_blade_U=topstrain .+ 1.0,
-            topstrainout_blade_L=topstrain .+ 2.0,
-            topstrainout_tower_U=topstrain .+ 3.0,
-            topstrainout_tower_L=topstrain .+ 4.0,
-            topDamage_blade_U=damage .+ 1.0,
-            topDamage_blade_L=damage .+ 2.0,
-            topDamage_tower_U=damage .+ 3.0,
-            topDamage_tower_L=damage .+ 4.0,
+            t = vector,
+            aziHist = vector .+ 0.1,
+            OmegaHist = vector .+ 0.2,
+            OmegaDotHist = vector .+ 0.3,
+            gbHist = vector .+ 0.4,
+            gbDotHist = vector .+ 0.5,
+            gbDotDotHist = vector .+ 0.6,
+            FReactionHist = dof_history,
+            FTwrBsHist = dof_history .+ 10.0,
+            genTorque = vector .+ 0.7,
+            genPower = vector .+ 0.8,
+            torqueDriveShaft = vector .+ 0.9,
+            uHist = dof_history .+ 20.0,
+            uHist_prp = dof_history .+ 30.0,
+            epsilon_x_hist = strain_history .+ 1.0,
+            epsilon_y_hist = strain_history .+ 2.0,
+            epsilon_z_hist = strain_history .+ 3.0,
+            kappa_x_hist = strain_history .+ 4.0,
+            kappa_y_hist = strain_history .+ 5.0,
+            kappa_z_hist = strain_history .+ 6.0,
+            massOwens = 12.5,
+            stress_U = stress_history .+ 1.0,
+            SF_ult_U = safety_factor .+ 1.0,
+            SF_buck_U = safety_factor .+ 2.0,
+            stress_L = stress_history .+ 2.0,
+            SF_ult_L = safety_factor .+ 3.0,
+            SF_buck_L = safety_factor .+ 4.0,
+            stress_TU = stress_history .+ 3.0,
+            SF_ult_TU = safety_factor .+ 5.0,
+            SF_buck_TU = safety_factor .+ 6.0,
+            stress_TL = stress_history .+ 4.0,
+            SF_ult_TL = safety_factor .+ 7.0,
+            SF_buck_TL = safety_factor .+ 8.0,
+            topstrainout_blade_U = topstrain .+ 1.0,
+            topstrainout_blade_L = topstrain .+ 2.0,
+            topstrainout_tower_U = topstrain .+ 3.0,
+            topstrainout_tower_L = topstrain .+ 4.0,
+            topDamage_blade_U = damage .+ 1.0,
+            topDamage_blade_L = damage .+ 2.0,
+            topDamage_tower_U = damage .+ 3.0,
+            topDamage_tower_L = damage .+ 4.0,
         )
 
         h5_file = joinpath(dir, "unit.h5")
@@ -178,47 +179,47 @@ end
 
         OWENS.outputData(;
             inputs,
-            t=vector,
-            aziHist=vector .+ 0.1,
-            OmegaHist=vector .+ 0.2,
-            OmegaDotHist=vector .+ 0.3,
-            gbHist=vector .+ 0.4,
-            gbDotHist=vector .+ 0.5,
-            gbDotDotHist=vector .+ 0.6,
-            FReactionHist=dof_history,
-            FTwrBsHist=dof_history .+ 10.0,
-            genTorque=vector .+ 0.7,
-            genPower=vector .+ 0.8,
-            torqueDriveShaft=vector .+ 0.9,
-            uHist=dof_history .+ 20.0,
-            uHist_prp=dof_history .+ 30.0,
-            epsilon_x_hist=strain_history .+ 1.0,
-            epsilon_y_hist=strain_history .+ 2.0,
-            epsilon_z_hist=strain_history .+ 3.0,
-            kappa_x_hist=strain_history .+ 4.0,
-            kappa_y_hist=strain_history .+ 5.0,
-            kappa_z_hist=strain_history .+ 6.0,
-            massOwens=12.5,
-            stress_U=stress_history .+ 1.0,
-            SF_ult_U=safety_factor .+ 1.0,
-            SF_buck_U=safety_factor .+ 2.0,
-            stress_L=stress_history .+ 2.0,
-            SF_ult_L=safety_factor .+ 3.0,
-            SF_buck_L=safety_factor .+ 4.0,
-            stress_TU=stress_history .+ 3.0,
-            SF_ult_TU=safety_factor .+ 5.0,
-            SF_buck_TU=safety_factor .+ 6.0,
-            stress_TL=stress_history .+ 4.0,
-            SF_ult_TL=safety_factor .+ 7.0,
-            SF_buck_TL=safety_factor .+ 8.0,
-            topstrainout_blade_U=topstrain .+ 1.0,
-            topstrainout_blade_L=topstrain .+ 2.0,
-            topstrainout_tower_U=topstrain .+ 3.0,
-            topstrainout_tower_L=topstrain .+ 4.0,
-            topDamage_blade_U=damage .+ 1.0,
-            topDamage_blade_L=damage .+ 2.0,
-            topDamage_tower_U=damage .+ 3.0,
-            topDamage_tower_L=damage .+ 4.0,
+            t = vector,
+            aziHist = vector .+ 0.1,
+            OmegaHist = vector .+ 0.2,
+            OmegaDotHist = vector .+ 0.3,
+            gbHist = vector .+ 0.4,
+            gbDotHist = vector .+ 0.5,
+            gbDotDotHist = vector .+ 0.6,
+            FReactionHist = dof_history,
+            FTwrBsHist = dof_history .+ 10.0,
+            genTorque = vector .+ 0.7,
+            genPower = vector .+ 0.8,
+            torqueDriveShaft = vector .+ 0.9,
+            uHist = dof_history .+ 20.0,
+            uHist_prp = dof_history .+ 30.0,
+            epsilon_x_hist = strain_history .+ 1.0,
+            epsilon_y_hist = strain_history .+ 2.0,
+            epsilon_z_hist = strain_history .+ 3.0,
+            kappa_x_hist = strain_history .+ 4.0,
+            kappa_y_hist = strain_history .+ 5.0,
+            kappa_z_hist = strain_history .+ 6.0,
+            massOwens = 12.5,
+            stress_U = stress_history .+ 1.0,
+            SF_ult_U = safety_factor .+ 1.0,
+            SF_buck_U = safety_factor .+ 2.0,
+            stress_L = stress_history .+ 2.0,
+            SF_ult_L = safety_factor .+ 3.0,
+            SF_buck_L = safety_factor .+ 4.0,
+            stress_TU = stress_history .+ 3.0,
+            SF_ult_TU = safety_factor .+ 5.0,
+            SF_buck_TU = safety_factor .+ 6.0,
+            stress_TL = stress_history .+ 4.0,
+            SF_ult_TL = safety_factor .+ 7.0,
+            SF_buck_TL = safety_factor .+ 8.0,
+            topstrainout_blade_U = topstrain .+ 1.0,
+            topstrainout_blade_L = topstrain .+ 2.0,
+            topstrainout_tower_U = topstrain .+ 3.0,
+            topstrainout_tower_L = topstrain .+ 4.0,
+            topDamage_blade_U = damage .+ 1.0,
+            topDamage_blade_L = damage .+ 2.0,
+            topDamage_tower_U = damage .+ 3.0,
+            topDamage_tower_L = damage .+ 4.0,
         )
 
         h5_file = joinpath(dir, "unit.h5")
@@ -295,5 +296,264 @@ end
             channels = ["not_a_channel"],
         )
         @test_throws ArgumentError OWENS.output_data_summary(joinpath(dir, "missing.h5"))
+    end
+end
+
+@testset "outputData channel metrics" begin
+    mktempdir() do dir
+        reference_file = joinpath(dir, "reference.h5")
+        candidate_file = joinpath(dir, "candidate.h5")
+
+        reference_reactions = reshape(collect(1.0:6.0), 2, 3)
+        HDF5.h5open(reference_file, "w") do file
+            HDF5.write(file, "t", [1.0, 2.0, 3.0])
+            HDF5.write(file, "FReactionHist", reference_reactions)
+            HDF5.write(file, "OmegaHist", [0.0, 0.0])
+            HDF5.write(file, "OmegaDotHist", [0.0, 0.0])
+            HDF5.write(file, "massOwens", 12.5)
+        end
+        HDF5.h5open(candidate_file, "w") do file
+            HDF5.write(file, "t", [2.0, 1.0, 5.0])
+            HDF5.write(file, "FReactionHist", reference_reactions .+ 0.5)
+            HDF5.write(file, "OmegaHist", [0.0, 0.0])
+            HDF5.write(file, "OmegaDotHist", [1.0, 0.0])
+            HDF5.write(file, "genPower", [10.0, 20.0, 30.0])
+            HDF5.write(file, "massOwens", 13.0)
+        end
+
+        metrics = OWENS.output_data_channel_metrics(
+            reference_file,
+            candidate_file;
+            channels = ["t", "FReactionHist", "massOwens"],
+        )
+        @test length(metrics) == 3
+        @test [row.name for row in metrics] == ["t", "FReactionHist", "massOwens"]
+        @test keys(metrics[1]) == (
+            :name,
+            :comparable,
+            :passed,
+            :status,
+            :units,
+            :dimensions,
+            :reference_shape,
+            :candidate_shape,
+            :n,
+            :bias,
+            :rmse,
+            :max_abs_error,
+            :mean_abs_error,
+            :reference_rms,
+            :max_abs_reference,
+            :relative_rmse,
+            :tolerance,
+        )
+
+        time_metric = metrics[1]
+        @test time_metric.comparable === true
+        @test time_metric.passed === false
+        @test time_metric.status == "fail"
+        @test time_metric.units == "s"
+        @test time_metric.dimensions == ["time"]
+        @test time_metric.reference_shape == [3]
+        @test time_metric.candidate_shape == [3]
+        @test time_metric.n == 3
+        @test time_metric.bias == 2.0 / 3.0
+        @test time_metric.rmse == sqrt(2.0)
+        @test time_metric.max_abs_error == 2.0
+        @test time_metric.mean_abs_error == 4.0 / 3.0
+        @test time_metric.reference_rms == sqrt(14.0 / 3.0)
+        @test time_metric.max_abs_reference == 3.0
+        @test time_metric.relative_rmse == sqrt(2.0) / sqrt(14.0 / 3.0)
+        @test time_metric.tolerance == 1.0e-6 * 3.0
+
+        reaction_metric = metrics[2]
+        @test reaction_metric.comparable === true
+        @test reaction_metric.passed === false
+        @test reaction_metric.status == "fail"
+        @test reaction_metric.units == "N or N*m by DOF"
+        @test reaction_metric.dimensions == ["time", "structural_dof"]
+        @test reaction_metric.reference_shape == [2, 3]
+        @test reaction_metric.candidate_shape == [2, 3]
+        @test reaction_metric.n == 6
+        @test reaction_metric.bias == 0.5
+        @test reaction_metric.rmse == 0.5
+        @test reaction_metric.max_abs_error == 0.5
+        @test reaction_metric.mean_abs_error == 0.5
+        @test reaction_metric.reference_rms == sqrt(91.0 / 6.0)
+        @test reaction_metric.max_abs_reference == 6.0
+        @test reaction_metric.relative_rmse == 0.5 / sqrt(91.0 / 6.0)
+        @test reaction_metric.tolerance == 1.0e-6 * 6.0
+
+        scalar_metric = metrics[3]
+        @test scalar_metric.comparable === true
+        @test scalar_metric.passed === false
+        @test scalar_metric.status == "fail"
+        @test scalar_metric.reference_shape == Int[]
+        @test scalar_metric.candidate_shape == Int[]
+        @test scalar_metric.n == 1
+        @test scalar_metric.bias == 0.5
+        @test scalar_metric.rmse == 0.5
+        @test scalar_metric.max_abs_error == 0.5
+        @test scalar_metric.mean_abs_error == 0.5
+        @test scalar_metric.reference_rms == 12.5
+        @test scalar_metric.max_abs_reference == 12.5
+        @test scalar_metric.relative_rmse == 0.5 / 12.5
+        @test scalar_metric.tolerance == 1.0e-6 * 12.5
+
+        relaxed_metrics = OWENS.output_data_channel_metrics(
+            reference_file,
+            candidate_file;
+            channels = ["t", "FReactionHist", "massOwens"],
+            atol = 2.0,
+        )
+        @test [row.passed for row in relaxed_metrics] == [true, true, true]
+        @test [row.status for row in relaxed_metrics] == ["pass", "pass", "pass"]
+        @test [row.tolerance for row in relaxed_metrics] == [2.0 + 1.0e-6 * 3.0, 2.0 + 1.0e-6 * 6.0, 2.0 + 1.0e-6 * 12.5]
+
+        string_channel_metric = OWENS.output_data_channel_metrics(
+            reference_file,
+            candidate_file;
+            channels = "t",
+            atol = 2.0,
+        )
+        @test length(string_channel_metric) == 1
+        @test string_channel_metric[1] == relaxed_metrics[1]
+
+        zero_scale_metrics = OWENS.output_data_channel_metrics(
+            reference_file,
+            candidate_file;
+            channels = ["OmegaHist", "OmegaDotHist"],
+        )
+        @test zero_scale_metrics[1].status == "pass"
+        @test zero_scale_metrics[1].relative_rmse == 0.0
+        @test zero_scale_metrics[1].tolerance == 0.0
+        @test zero_scale_metrics[2].status == "fail"
+        @test zero_scale_metrics[2].relative_rmse == Inf
+        @test zero_scale_metrics[2].max_abs_error == 1.0
+        @test zero_scale_metrics[2].tolerance == 0.0
+
+        missing_reference_file = joinpath(dir, "missing_reference.h5")
+        HDF5.h5open(missing_reference_file, "w") do file
+            HDF5.write(file, "t", [1.0, 2.0, 3.0])
+        end
+        missing_reference_metric = OWENS.output_data_channel_metrics(
+            missing_reference_file,
+            candidate_file;
+            channels = ["genPower"],
+        )
+        @test missing_reference_metric[1].comparable === false
+        @test missing_reference_metric[1].passed === false
+        @test missing_reference_metric[1].status == "missing_reference"
+        @test ismissing(missing_reference_metric[1].reference_shape)
+        @test missing_reference_metric[1].candidate_shape == [3]
+        @test missing_reference_metric[1].n == 0
+        @test ismissing(missing_reference_metric[1].rmse)
+        @test ismissing(missing_reference_metric[1].tolerance)
+
+        missing_candidate_metric = OWENS.output_data_channel_metrics(
+            reference_file,
+            missing_reference_file;
+            channels = ["massOwens"],
+        )
+        @test missing_candidate_metric[1].comparable === false
+        @test missing_candidate_metric[1].passed === false
+        @test missing_candidate_metric[1].status == "missing_candidate"
+        @test missing_candidate_metric[1].reference_shape == Int[]
+        @test ismissing(missing_candidate_metric[1].candidate_shape)
+
+        missing_both_metric = OWENS.output_data_channel_metrics(
+            missing_reference_file,
+            missing_reference_file;
+            channels = ["genTorque"],
+        )
+        @test missing_both_metric[1].comparable === false
+        @test missing_both_metric[1].passed === false
+        @test missing_both_metric[1].status == "missing_reference_and_candidate"
+        @test ismissing(missing_both_metric[1].reference_shape)
+        @test ismissing(missing_both_metric[1].candidate_shape)
+
+        shape_mismatch_file = joinpath(dir, "shape_mismatch.h5")
+        HDF5.h5open(shape_mismatch_file, "w") do file
+            HDF5.write(file, "t", [1.0, 2.0])
+        end
+        shape_mismatch_metric = OWENS.output_data_channel_metrics(
+            reference_file,
+            shape_mismatch_file;
+            channels = ["t"],
+        )
+        @test shape_mismatch_metric[1].comparable === false
+        @test shape_mismatch_metric[1].passed === false
+        @test shape_mismatch_metric[1].status == "shape_mismatch"
+        @test shape_mismatch_metric[1].reference_shape == [3]
+        @test shape_mismatch_metric[1].candidate_shape == [2]
+        @test ismissing(shape_mismatch_metric[1].max_abs_error)
+
+        nonnumeric_file = joinpath(dir, "nonnumeric.h5")
+        HDF5.h5open(nonnumeric_file, "w") do file
+            HDF5.write(file, "genTorque", "not numeric")
+        end
+        nonnumeric_metric = OWENS.output_data_channel_metrics(
+            nonnumeric_file,
+            nonnumeric_file;
+            channels = ["genTorque"],
+        )
+        @test nonnumeric_metric[1].comparable === false
+        @test nonnumeric_metric[1].passed === false
+        @test nonnumeric_metric[1].status == "non_numeric"
+        @test nonnumeric_metric[1].reference_shape == Int[]
+        @test nonnumeric_metric[1].candidate_shape == Int[]
+
+        nonfinite_file = joinpath(dir, "nonfinite.h5")
+        HDF5.h5open(nonfinite_file, "w") do file
+            HDF5.write(file, "t", [1.0, NaN])
+        end
+        nonfinite_metric = OWENS.output_data_channel_metrics(
+            nonfinite_file,
+            nonfinite_file;
+            channels = ["t"],
+        )
+        @test nonfinite_metric[1].comparable === false
+        @test nonfinite_metric[1].passed === false
+        @test nonfinite_metric[1].status == "non_finite"
+        @test nonfinite_metric[1].reference_shape == [2]
+        @test nonfinite_metric[1].candidate_shape == [2]
+
+        empty_file = joinpath(dir, "empty.h5")
+        HDF5.h5open(empty_file, "w") do file
+            HDF5.write(file, "t", Float64[])
+        end
+        empty_metric =
+            OWENS.output_data_channel_metrics(empty_file, empty_file; channels = ["t"])
+        @test empty_metric[1].comparable === false
+        @test empty_metric[1].passed === false
+        @test empty_metric[1].status == "empty"
+        @test empty_metric[1].reference_shape == [0]
+        @test empty_metric[1].candidate_shape == [0]
+
+        @test_throws KeyError OWENS.output_data_channel_metrics(
+            reference_file,
+            candidate_file;
+            channels = ["not_a_channel"],
+        )
+        @test_throws ArgumentError OWENS.output_data_channel_metrics(
+            reference_file,
+            candidate_file;
+            channels = ["t"],
+            atol = -1.0,
+        )
+        @test_throws ArgumentError OWENS.output_data_channel_metrics(
+            reference_file,
+            candidate_file;
+            channels = ["t"],
+            rtol = -1.0,
+        )
+        @test_throws ArgumentError OWENS.output_data_channel_metrics(
+            joinpath(dir, "does_not_exist_reference.h5"),
+            candidate_file,
+        )
+        @test_throws ArgumentError OWENS.output_data_channel_metrics(
+            reference_file,
+            joinpath(dir, "does_not_exist_candidate.h5"),
+        )
     end
 end


### PR DESCRIPTION
Adds selected numeric HDF5 outputData channel comparison metrics with bias, RMSE, max and mean absolute error, relative RMSE, and tolerance pass/fail rows. Depends on PR 144. Tests: julia --project=. test/test_output_data_channels.jl; stacked cheap block covering run manifests, output data channels, WindIO run spec, and VTK history output; JuliaFormatter file checks; git diff --check.