### PR TITLE
Validate run manifest schema

### DIFF
--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -31,6 +31,11 @@ rtol)` to compare selected numeric channels from two result files. It reports
 bias, RMSE, maximum absolute error, mean absolute error, reference RMS, relative
 RMSE, and a pass/fail result using `atol + rtol * max_abs_reference`.
 
+Use `run_manifest_issues(manifest_or_path)` and
+`validate_run_manifest(manifest_or_path)` to check that provenance manifests
+retain the expected schema, file-record shape, byte counts, and SHA-256 digest
+format before a GUI or validation dashboard trusts them.
+
 The public helpers are:
 
 - `ResultChannel`
@@ -46,5 +51,7 @@ The public helpers are:
 - `write_windio_run_script(path, spec)`
 - `build_windio_run_manifest(spec)`
 - `write_windio_run_manifest(path, spec)`
+- `run_manifest_issues(manifest_or_path)`
+- `validate_run_manifest(manifest_or_path)`
 
 The generated API listing above includes their full docstrings.

--- a/src/io/provenance.jl
+++ b/src/io/provenance.jl
@@ -4,9 +4,29 @@ export file_sha256,
     collect_package_versions,
     build_run_manifest,
     write_run_manifest,
-    read_run_manifest
+    read_run_manifest,
+    run_manifest_issues,
+    validate_run_manifest
 
 const RUN_MANIFEST_SCHEMA_VERSION = "owens-run-manifest/v1"
+const RUN_MANIFEST_REQUIRED_KEYS = [
+    "schema_version",
+    "run_id",
+    "run_name",
+    "created_at_utc",
+    "project_root",
+    "solver",
+    "status",
+    "julia",
+    "packages",
+    "git",
+    "parameters",
+    "metadata",
+    "inputs",
+    "outputs",
+    "generated",
+    "warnings",
+]
 
 """
     file_sha256(path)
@@ -199,6 +219,69 @@ function read_run_manifest(path::AbstractString)
     return YAML.load_file(path; dicttype = OrderedCollections.OrderedDict{String,Any})
 end
 
+"""
+    run_manifest_issues(manifest_or_path)
+
+Return deterministic schema and type diagnostics for an OWENS run manifest.
+The validator checks the manifest shape and file-record hashes without requiring
+archived files to still exist on disk.
+"""
+run_manifest_issues(path::AbstractString) = run_manifest_issues(read_run_manifest(path))
+
+function run_manifest_issues(manifest::AbstractDict)
+    issues = String[]
+    for key in RUN_MANIFEST_REQUIRED_KEYS
+        _require_manifest_key!(issues, manifest, key)
+    end
+
+    if haskey(manifest, "schema_version") &&
+       manifest["schema_version"] != RUN_MANIFEST_SCHEMA_VERSION
+        push!(issues, "schema_version must equal $RUN_MANIFEST_SCHEMA_VERSION")
+    end
+
+    for key in ("run_id", "run_name", "created_at_utc", "project_root", "solver", "status")
+        _require_manifest_string!(issues, manifest, key)
+    end
+
+    for key in ("julia", "packages", "git", "parameters", "metadata")
+        _require_manifest_dict!(issues, manifest, key)
+    end
+
+    for key in ("inputs", "outputs", "generated", "warnings")
+        _require_manifest_vector!(issues, manifest, key)
+    end
+
+    for section in ("inputs", "outputs", "generated")
+        if haskey(manifest, section) && manifest[section] isa AbstractVector
+            for (index, record) in enumerate(manifest[section])
+                _manifest_file_record_issues!(issues, section, index, record)
+            end
+        end
+    end
+
+    if haskey(manifest, "warnings") && manifest["warnings"] isa AbstractVector
+        for (index, warning) in enumerate(manifest["warnings"])
+            warning isa AbstractString || push!(issues, "warnings[$index] must be a string")
+        end
+    end
+
+    return issues
+end
+
+"""
+    validate_run_manifest(manifest_or_path)
+
+Return a valid manifest, or throw `ArgumentError` with all schema diagnostics.
+"""
+validate_run_manifest(path::AbstractString) = validate_run_manifest(read_run_manifest(path))
+
+function validate_run_manifest(manifest::AbstractDict)
+    issues = run_manifest_issues(manifest)
+    isempty(issues) ||
+        throw(ArgumentError("Invalid OWENS run manifest:\n- " * join(issues, "\n- ")))
+    return manifest
+end
+
 function _push_file_record!(records, path, root::AbstractString, role::AbstractString)
     if !isnothing(path)
         push!(records, file_provenance(string(path); root = root, role = role))
@@ -206,6 +289,82 @@ function _push_file_record!(records, path, root::AbstractString, role::AbstractS
 
     return records
 end
+
+function _require_manifest_key!(issues::Vector{String}, manifest::AbstractDict, key::String)
+    haskey(manifest, key) || push!(issues, "missing required key: $key")
+    return issues
+end
+
+function _require_manifest_string!(
+    issues::Vector{String},
+    manifest::AbstractDict,
+    key::String,
+)
+    haskey(manifest, key) || return issues
+    manifest[key] isa AbstractString || push!(issues, "$key must be a string")
+    return issues
+end
+
+function _require_manifest_dict!(
+    issues::Vector{String},
+    manifest::AbstractDict,
+    key::String,
+)
+    haskey(manifest, key) || return issues
+    manifest[key] isa AbstractDict || push!(issues, "$key must be a dictionary")
+    return issues
+end
+
+function _require_manifest_vector!(
+    issues::Vector{String},
+    manifest::AbstractDict,
+    key::String,
+)
+    haskey(manifest, key) || return issues
+    manifest[key] isa AbstractVector || push!(issues, "$key must be a vector")
+    return issues
+end
+
+function _manifest_file_record_issues!(
+    issues::Vector{String},
+    section::AbstractString,
+    index::Integer,
+    record,
+)
+    prefix = "$section[$index]"
+    if !(record isa AbstractDict)
+        push!(issues, "$prefix must be a dictionary")
+        return issues
+    end
+
+    if !haskey(record, "path")
+        push!(issues, "$prefix.path is required")
+    elseif !(record["path"] isa AbstractString)
+        push!(issues, "$prefix.path must be a string")
+    end
+
+    if !haskey(record, "bytes")
+        push!(issues, "$prefix.bytes is required")
+    elseif !_is_nonnegative_integer(record["bytes"])
+        push!(issues, "$prefix.bytes must be a non-negative integer")
+    end
+
+    if !haskey(record, "sha256")
+        push!(issues, "$prefix.sha256 is required")
+    elseif !_is_sha256_digest(record["sha256"])
+        push!(issues, "$prefix.sha256 must be a lowercase 64-character SHA-256 digest")
+    end
+
+    if haskey(record, "role") && !(record["role"] isa AbstractString)
+        push!(issues, "$prefix.role must be a string when present")
+    end
+
+    return issues
+end
+
+_is_nonnegative_integer(value) = value isa Integer && !(value isa Bool) && value >= 0
+
+_is_sha256_digest(value) = value isa AbstractString && occursin(r"^[0-9a-f]{64}$", value)
 
 function _manifest_value(value)
     if value isa AbstractDict

--- a/test/test_run_manifest.jl
+++ b/test/test_run_manifest.jl
@@ -15,7 +15,7 @@ const GENERATED_SHA256 = "90e6df81ce3177ae762f91b5d27efa667cc2efcdc9c7e7310a45fb
         input_file = joinpath(dir, "input.txt")
         write(input_file, "alpha\n")
 
-        record = OWENS.file_provenance(input_file; root=dir, role=:airfoil)
+        record = OWENS.file_provenance(input_file; root = dir, role = :airfoil)
         @test record isa OrderedCollections.OrderedDict{String,Any}
         @test collect(keys(record)) == ["path", "bytes", "sha256", "role"]
         @test record["path"] == "input.txt"
@@ -29,7 +29,7 @@ const GENERATED_SHA256 = "90e6df81ce3177ae762f91b5d27efa667cc2efcdc9c7e7310a45fb
 
         missing_file = joinpath(dir, "missing.txt")
         @test_throws ArgumentError OWENS.file_sha256(missing_file)
-        @test_throws ArgumentError OWENS.file_provenance(missing_file; root=dir)
+        @test_throws ArgumentError OWENS.file_provenance(missing_file; root = dir)
     end
 end
 
@@ -54,19 +54,19 @@ end
         metadata = Dict(:case => "unit", :active => true)
 
         manifest = OWENS.build_run_manifest(;
-            run_id="run-unit-001",
-            run_name="manifest unit test",
-            project_root=dir,
-            solver="unit-solver",
-            project_file=project_file,
-            input_files=[input_file],
-            output_files=[output_file],
-            generated_files=[generated_file],
+            run_id = "run-unit-001",
+            run_name = "manifest unit test",
+            project_root = dir,
+            solver = "unit-solver",
+            project_file = project_file,
+            input_files = [input_file],
+            output_files = [output_file],
+            generated_files = [generated_file],
             parameters,
             metadata,
-            warnings=["low residual warning"],
-            status="complete",
-            created_at_utc="2026-05-20T00:00:00.000Z",
+            warnings = ["low residual warning"],
+            status = "complete",
+            created_at_utc = "2026-05-20T00:00:00.000Z",
         )
 
         @test manifest isa OrderedCollections.OrderedDict{String,Any}
@@ -132,6 +132,8 @@ end
         @test collect(keys(manifest["metadata"])) == ["active", "case"]
         @test manifest["metadata"]["active"] === true
         @test manifest["metadata"]["case"] == "unit"
+        @test OWENS.run_manifest_issues(manifest) == String[]
+        @test OWENS.validate_run_manifest(manifest) === manifest
 
         written = OWENS.write_run_manifest(manifest_file, manifest)
         loaded = OWENS.read_run_manifest(manifest_file)
@@ -143,6 +145,8 @@ end
         @test loaded["outputs"][1]["sha256"] == OUTPUT_SHA256
         @test loaded["generated"][1]["sha256"] == GENERATED_SHA256
         @test loaded["parameters"]["flags"] == ["tip_loss", "dynamic_stall"]
+        @test OWENS.run_manifest_issues(manifest_file) == String[]
+        @test OWENS.validate_run_manifest(manifest_file)["run_id"] == "run-unit-001"
 
         @test_throws ArgumentError OWENS.read_run_manifest(joinpath(dir, "missing.yml"))
     end
@@ -175,6 +179,93 @@ end
     @test OWENS._manifest_value(v"2.0.1") == "2.0.1"
     @test OWENS._manifest_value(Dates.Date(2026, 5, 22)) == "2026-05-22"
     @test OWENS._manifest_value((:alpha, v"1.0.0")) == ["alpha", "1.0.0"]
+end
+
+@testset "Run manifest validation diagnostics" begin
+    mktempdir() do dir
+        input_file = joinpath(dir, "input.yml")
+        output_file = joinpath(dir, "output.h5")
+        write(input_file, "input: unit\n")
+        write(output_file, "output: unit\n")
+
+        manifest = OWENS.build_run_manifest(;
+            run_id = "validation-unit",
+            run_name = "validation unit",
+            project_root = dir,
+            solver = "unit-solver",
+            input_files = [input_file],
+            output_files = [output_file],
+            warnings = ["unit warning"],
+            status = "complete",
+            created_at_utc = "2026-05-20T00:00:00.000Z",
+        )
+        @test OWENS.run_manifest_issues(manifest) == String[]
+
+        missing_schema = deepcopy(manifest)
+        delete!(missing_schema, "schema_version")
+        @test OWENS.run_manifest_issues(missing_schema) ==
+              ["missing required key: schema_version"]
+
+        old_schema = deepcopy(manifest)
+        old_schema["schema_version"] = "owens-run-manifest/v0"
+        @test OWENS.run_manifest_issues(old_schema) ==
+              ["schema_version must equal owens-run-manifest/v1"]
+
+        malformed = deepcopy(manifest)
+        malformed["run_id"] = 42
+        malformed["created_at_utc"] = false
+        malformed["julia"] = "Julia 1.12"
+        malformed["parameters"] = ["rpm"]
+        malformed["inputs"] = [
+            Dict(
+                "path" => 42,
+                "bytes" => true,
+                "sha256" => uppercase(INPUT_SHA256),
+                "role" => 7,
+            ),
+            "not a record",
+        ]
+        malformed["outputs"] =
+            [Dict("path" => "output.h5", "bytes" => -1, "sha256" => "abc")]
+        malformed["generated"] = [Dict("path" => "generated.vtp", "bytes" => 1)]
+        malformed["warnings"] = [3]
+        @test OWENS.run_manifest_issues(malformed) == [
+            "run_id must be a string",
+            "created_at_utc must be a string",
+            "julia must be a dictionary",
+            "parameters must be a dictionary",
+            "inputs[1].path must be a string",
+            "inputs[1].bytes must be a non-negative integer",
+            "inputs[1].sha256 must be a lowercase 64-character SHA-256 digest",
+            "inputs[1].role must be a string when present",
+            "inputs[2] must be a dictionary",
+            "outputs[1].bytes must be a non-negative integer",
+            "outputs[1].sha256 must be a lowercase 64-character SHA-256 digest",
+            "generated[1].sha256 is required",
+            "warnings[1] must be a string",
+        ]
+        @test_throws ArgumentError OWENS.validate_run_manifest(malformed)
+
+        missing_keys = OrderedCollections.OrderedDict{String,Any}()
+        @test OWENS.run_manifest_issues(missing_keys) == [
+            "missing required key: schema_version",
+            "missing required key: run_id",
+            "missing required key: run_name",
+            "missing required key: created_at_utc",
+            "missing required key: project_root",
+            "missing required key: solver",
+            "missing required key: status",
+            "missing required key: julia",
+            "missing required key: packages",
+            "missing required key: git",
+            "missing required key: parameters",
+            "missing required key: metadata",
+            "missing required key: inputs",
+            "missing required key: outputs",
+            "missing required key: generated",
+            "missing required key: warnings",
+        ]
+    end
 end
 
 @testset "Git state outside repository" begin


### PR DESCRIPTION
Adds run manifest schema diagnostics and validation helpers for provenance and GUI health checks. Depends on PR 145. Tests: julia --project=. test/test_run_manifest.jl; stacked cheap block covering run manifests, output data channels, WindIO run spec, and VTK history output; JuliaFormatter file checks; git diff --check.