### PR TITLE
Add output data validation reports

### DIFF
--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -36,6 +36,14 @@ Use `run_manifest_issues(manifest_or_path)` and
 retain the expected schema, file-record shape, byte counts, and SHA-256 digest
 format before a GUI or validation dashboard trusts them.
 
+Use `build_output_data_validation_report(reference_path, candidate_path; ...)`
+and `write_output_data_validation_report(path, reference_path, candidate_path;
+...)` to package selected-channel metric rows into a durable YAML artifact for
+regression dashboards. The report intentionally performs elementwise
+comparisons only; validation cases that need time alignment, phase correction,
+or whole-revolution windows should preprocess the selected channels before
+report generation.
+
 The public helpers are:
 
 - `ResultChannel`
@@ -53,5 +61,8 @@ The public helpers are:
 - `write_windio_run_manifest(path, spec)`
 - `run_manifest_issues(manifest_or_path)`
 - `validate_run_manifest(manifest_or_path)`
+- `build_output_data_validation_report(reference_path, candidate_path)`
+- `write_output_data_validation_report(path, reference_path, candidate_path)`
+- `read_output_data_validation_report(path)`
 
 The generated API listing above includes their full docstrings.

--- a/src/OWENS.jl
+++ b/src/OWENS.jl
@@ -78,6 +78,7 @@ include("io/fileio.jl")
 include("io/windio_run_spec.jl")
 include("io/windio.jl")
 include("io/provenance.jl")
+include("io/validation_reports.jl")
 
 # Preprocessing functionality
 include("preprocessing/gxbeam_conversion.jl")

--- a/src/io/validation_reports.jl
+++ b/src/io/validation_reports.jl
@@ -1,0 +1,224 @@
+export build_output_data_validation_report,
+    write_output_data_validation_report, read_output_data_validation_report
+
+const OUTPUT_DATA_VALIDATION_REPORT_SCHEMA_VERSION = "owens-output-data-validation/v1"
+const OUTPUT_DATA_VALIDATION_NOTE = "Elementwise comparison of selected registered outputData channels; no time alignment, interpolation, phase correction, or whole-revolution windowing is applied."
+
+"""
+    build_output_data_validation_report(reference_path, candidate_path; channels, atol, rtol, tolerances, case_id, metadata, created_at_utc)
+
+Build a deterministic YAML-friendly report around `output_data_channel_metrics`.
+The report is intended for regression dashboards and GUI validation panels; it
+compares selected registered channels elementwise and records per-channel metric
+rows, tolerances, file hashes, and a concise summary.
+"""
+function build_output_data_validation_report(
+    reference_path::AbstractString,
+    candidate_path::AbstractString;
+    channels = output_data_channel_names(),
+    atol::Real = 0.0,
+    rtol::Real = 1e-6,
+    tolerances = OrderedCollections.OrderedDict{String,Any}(),
+    case_id::AbstractString = "output-data-comparison",
+    metadata = OrderedCollections.OrderedDict{String,Any}(),
+    created_at_utc = nothing,
+)
+    requested_channels = _output_summary_channels(channels)
+    tolerance_map =
+        _output_validation_tolerances(requested_channels, tolerances, atol, rtol)
+    rows = OrderedCollections.OrderedDict{String,Any}[]
+    for channel in requested_channels
+        channel_tolerance = tolerance_map[channel]
+        metrics = output_data_channel_metrics(
+            reference_path,
+            candidate_path;
+            channels = channel,
+            atol = channel_tolerance["atol"],
+            rtol = channel_tolerance["rtol"],
+        )
+        push!(rows, _output_validation_metric_row(metrics[1], channel_tolerance))
+    end
+
+    passed = all(row["passed"] === true for row in rows)
+    comparable_count = count(row -> row["comparable"] === true, rows)
+
+    return OrderedCollections.OrderedDict{String,Any}(
+        "schema_version" => OUTPUT_DATA_VALIDATION_REPORT_SCHEMA_VERSION,
+        "case_id" => string(case_id),
+        "created_at_utc" =>
+            isnothing(created_at_utc) ? _utc_timestamp() : string(created_at_utc),
+        "status" => passed ? "passed" : "failed",
+        "comparison" => OrderedCollections.OrderedDict{String,Any}(
+            "kind" => "outputData_channel_metrics",
+            "note" => OUTPUT_DATA_VALIDATION_NOTE,
+            "default_atol" => Float64(atol),
+            "default_rtol" => Float64(rtol),
+        ),
+        "reference" => _absolute_file_provenance(reference_path, "reference_output_data"),
+        "candidate" => _absolute_file_provenance(candidate_path, "candidate_output_data"),
+        "summary" => OrderedCollections.OrderedDict{String,Any}(
+            "channels_requested" => length(rows),
+            "channels_comparable" => comparable_count,
+            "channels_noncomparable" => length(rows) - comparable_count,
+            "channels_passed" => count(row -> row["passed"] === true, rows),
+            "channels_failed" => count(row -> row["passed"] === false, rows),
+        ),
+        "metadata" => _validation_report_value(metadata),
+        "channels" => rows,
+    )
+end
+
+"""
+    write_output_data_validation_report(path, reference_path, candidate_path; kwargs...)
+
+Build and write an output-data validation report. Returns the report that was
+written.
+"""
+function write_output_data_validation_report(
+    path::AbstractString,
+    reference_path::AbstractString,
+    candidate_path::AbstractString;
+    kwargs...,
+)
+    report = build_output_data_validation_report(reference_path, candidate_path; kwargs...)
+    parent = dirname(path)
+    if !isempty(parent)
+        mkpath(parent)
+    end
+
+    YAML.write_file(path, report)
+    return report
+end
+
+"""
+    read_output_data_validation_report(path)
+
+Read a YAML output-data validation report using string-keyed ordered
+dictionaries.
+"""
+function read_output_data_validation_report(path::AbstractString)
+    isfile(path) || throw(ArgumentError("Cannot read missing validation report: $path"))
+    return YAML.load_file(path; dicttype = OrderedCollections.OrderedDict{String,Any})
+end
+
+function _output_validation_tolerances(
+    channels::AbstractVector{<:AbstractString},
+    tolerances,
+    default_atol::Real,
+    default_rtol::Real,
+)
+    default_atol >= 0 || throw(
+        ArgumentError("default validation atol must be non-negative, got $default_atol"),
+    )
+    default_rtol >= 0 || throw(
+        ArgumentError("default validation rtol must be non-negative, got $default_rtol"),
+    )
+
+    tolerance_map = OrderedCollections.OrderedDict{String,Any}()
+    for channel in channels
+        channel_tolerance = _channel_validation_tolerance(tolerances, channel)
+        atol = get(channel_tolerance, "atol", default_atol)
+        rtol = get(channel_tolerance, "rtol", default_rtol)
+        atol >= 0 || throw(
+            ArgumentError("validation atol for $channel must be non-negative, got $atol"),
+        )
+        rtol >= 0 || throw(
+            ArgumentError("validation rtol for $channel must be non-negative, got $rtol"),
+        )
+        tolerance_map[string(channel)] = OrderedCollections.OrderedDict{String,Any}(
+            "atol" => Float64(atol),
+            "rtol" => Float64(rtol),
+        )
+    end
+
+    return tolerance_map
+end
+
+function _channel_validation_tolerance(tolerances, channel::AbstractString)
+    if isnothing(tolerances)
+        return OrderedCollections.OrderedDict{String,Any}()
+    end
+
+    if !(tolerances isa AbstractDict)
+        throw(ArgumentError("tolerances must be a dictionary keyed by channel name"))
+    end
+    isempty(tolerances) && return OrderedCollections.OrderedDict{String,Any}()
+
+    raw_tolerance =
+        haskey(tolerances, channel) ? tolerances[channel] :
+        get(tolerances, Symbol(channel), OrderedCollections.OrderedDict{String,Any}())
+    if raw_tolerance isa NamedTuple
+        return OrderedCollections.OrderedDict{String,Any}(
+            string(key) => raw_tolerance[key] for key in keys(raw_tolerance)
+        )
+    elseif raw_tolerance isa AbstractDict
+        return OrderedCollections.OrderedDict{String,Any}(
+            string(key) => value for (key, value) in raw_tolerance
+        )
+    else
+        throw(ArgumentError("tolerance for $channel must be a dictionary or named tuple"))
+    end
+end
+
+function _output_validation_metric_row(metric, tolerance::AbstractDict)
+    return OrderedCollections.OrderedDict{String,Any}(
+        "name" => metric.name,
+        "passed" => metric.passed,
+        "comparable" => metric.comparable,
+        "status" => metric.status,
+        "units" => metric.units,
+        "dimensions" => copy(metric.dimensions),
+        "reference_shape" => _validation_report_value(metric.reference_shape),
+        "candidate_shape" => _validation_report_value(metric.candidate_shape),
+        "n" => metric.n,
+        "bias" => _validation_report_value(metric.bias),
+        "rmse" => _validation_report_value(metric.rmse),
+        "max_abs_error" => _validation_report_value(metric.max_abs_error),
+        "mean_abs_error" => _validation_report_value(metric.mean_abs_error),
+        "reference_rms" => _validation_report_value(metric.reference_rms),
+        "max_abs_reference" => _validation_report_value(metric.max_abs_reference),
+        "relative_rmse" => _validation_report_value(metric.relative_rmse),
+        "tolerance" => _validation_report_value(metric.tolerance),
+        "atol" => tolerance["atol"],
+        "rtol" => tolerance["rtol"],
+    )
+end
+
+function _absolute_file_provenance(path::AbstractString, role::AbstractString)
+    record = file_provenance(path; root = dirname(abspath(path)), role = role)
+    record["path"] = abspath(path)
+    return record
+end
+
+function _validation_report_value(value)
+    if value === missing
+        return nothing
+    elseif value isa NamedTuple
+        return OrderedCollections.OrderedDict{String,Any}(
+            string(key) => _validation_report_value(getfield(value, key)) for
+            key in keys(value)
+        )
+    elseif value isa AbstractDict
+        normalized = OrderedCollections.OrderedDict{String,Any}()
+        keys_iter =
+            value isa OrderedCollections.OrderedDict ? collect(keys(value)) :
+            sort(collect(keys(value)); by = string)
+        for key in keys_iter
+            normalized[string(key)] = _validation_report_value(value[key])
+        end
+        return normalized
+    elseif value isa AbstractVector || value isa Tuple
+        return [_validation_report_value(item) for item in value]
+    elseif value isa Symbol
+        return string(value)
+    elseif value isa VersionNumber
+        return string(value)
+    elseif value isa AbstractString ||
+           value isa Number ||
+           value isa Bool ||
+           isnothing(value)
+        return value
+    else
+        return string(value)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,10 @@ end
     include("$path/test_output_data_channels.jl")
 end
 
+@testset "Output Data Validation Reports" begin
+    include("$path/test_validation_reports.jl")
+end
+
 @testset "WindIO Run Spec" begin
     include("$path/test_windio_run_spec.jl")
 end

--- a/test/test_validation_reports.jl
+++ b/test/test_validation_reports.jl
@@ -1,0 +1,209 @@
+using Test
+import HDF5
+import OWENS
+import OrderedCollections
+
+@testset "Output data validation report" begin
+    mktempdir() do dir
+        reference_file = joinpath(dir, "reference.h5")
+        candidate_file = joinpath(dir, "candidate.h5")
+        report_file = joinpath(dir, "reports", "validation.yml")
+
+        HDF5.h5open(reference_file, "w") do file
+            HDF5.write(file, "t", [0.0, 1.0, 2.0])
+            HDF5.write(file, "genPower", [10.0, 20.0, 30.0])
+            HDF5.write(file, "OmegaHist", [0.0, 0.0])
+            HDF5.write(file, "OmegaDotHist", [1.0, NaN])
+        end
+        HDF5.h5open(candidate_file, "w") do file
+            HDF5.write(file, "t", [0.0, 1.05, 1.95])
+            HDF5.write(file, "genPower", [10.0, 25.0, 30.0])
+            HDF5.write(file, "OmegaHist", [0.0, 0.0])
+            HDF5.write(file, "OmegaDotHist", [1.0, 2.0])
+        end
+
+        tolerances = OrderedCollections.OrderedDict{String,Any}(
+            "t" => (; atol = 0.1),
+            "genPower" => Dict(:rtol => 0.1),
+        )
+        report = OWENS.build_output_data_validation_report(
+            reference_file,
+            candidate_file;
+            channels = ["t", "genPower", "OmegaHist", "OmegaDotHist", "genTorque"],
+            tolerances,
+            case_id = "validation-report-unit",
+            metadata = Dict(:source => :unit, :active => true),
+            created_at_utc = "2026-05-20T00:00:00.000Z",
+        )
+
+        @test collect(keys(report)) == [
+            "schema_version",
+            "case_id",
+            "created_at_utc",
+            "status",
+            "comparison",
+            "reference",
+            "candidate",
+            "summary",
+            "metadata",
+            "channels",
+        ]
+        @test report["schema_version"] == "owens-output-data-validation/v1"
+        @test report["case_id"] == "validation-report-unit"
+        @test report["created_at_utc"] == "2026-05-20T00:00:00.000Z"
+        @test report["status"] == "failed"
+        @test report["comparison"]["kind"] == "outputData_channel_metrics"
+        @test report["comparison"]["default_atol"] == 0.0
+        @test report["comparison"]["default_rtol"] == 1.0e-6
+        @test report["comparison"]["note"] ==
+              "Elementwise comparison of selected registered outputData channels; no time alignment, interpolation, phase correction, or whole-revolution windowing is applied."
+        @test report["reference"]["path"] == abspath(reference_file)
+        @test report["reference"]["bytes"] == stat(reference_file).size
+        @test report["reference"]["sha256"] == OWENS.file_sha256(reference_file)
+        @test report["reference"]["role"] == "reference_output_data"
+        @test report["candidate"]["path"] == abspath(candidate_file)
+        @test report["candidate"]["bytes"] == stat(candidate_file).size
+        @test report["candidate"]["sha256"] == OWENS.file_sha256(candidate_file)
+        @test report["candidate"]["role"] == "candidate_output_data"
+        @test report["summary"] == OrderedCollections.OrderedDict{String,Any}(
+            "channels_requested" => 5,
+            "channels_comparable" => 3,
+            "channels_noncomparable" => 2,
+            "channels_passed" => 2,
+            "channels_failed" => 3,
+        )
+        @test collect(keys(report["metadata"])) == ["active", "source"]
+        @test report["metadata"]["active"] === true
+        @test report["metadata"]["source"] == "unit"
+
+        @test length(report["channels"]) == 5
+        @test [row["name"] for row in report["channels"]] == ["t", "genPower", "OmegaHist", "OmegaDotHist", "genTorque"]
+        @test collect(keys(report["channels"][1])) == [
+            "name",
+            "passed",
+            "comparable",
+            "status",
+            "units",
+            "dimensions",
+            "reference_shape",
+            "candidate_shape",
+            "n",
+            "bias",
+            "rmse",
+            "max_abs_error",
+            "mean_abs_error",
+            "reference_rms",
+            "max_abs_reference",
+            "relative_rmse",
+            "tolerance",
+            "atol",
+            "rtol",
+        ]
+
+        time_row = report["channels"][1]
+        @test time_row["passed"] === true
+        @test time_row["comparable"] === true
+        @test time_row["status"] == "pass"
+        @test time_row["units"] == "s"
+        @test time_row["dimensions"] == ["time"]
+        @test time_row["reference_shape"] == [3]
+        @test time_row["candidate_shape"] == [3]
+        @test time_row["n"] == 3
+        @test time_row["bias"] == 0.0
+        time_difference = [0.0, 1.05 - 1.0, 1.95 - 2.0]
+        @test time_row["rmse"] == sqrt(sum(abs2, time_difference) / 3.0)
+        @test time_row["max_abs_error"] == maximum(abs.(time_difference))
+        @test time_row["mean_abs_error"] == sum(abs.(time_difference)) / 3.0
+        @test time_row["reference_rms"] == sqrt(5.0 / 3.0)
+        @test time_row["max_abs_reference"] == 2.0
+        @test time_row["relative_rmse"] ==
+              sqrt(sum(abs2, time_difference) / 3.0) / sqrt(5.0 / 3.0)
+        @test time_row["tolerance"] == 0.1 + 1.0e-6 * 2.0
+        @test time_row["atol"] == 0.1
+        @test time_row["rtol"] == 1.0e-6
+
+        power_row = report["channels"][2]
+        @test power_row["passed"] === false
+        @test power_row["comparable"] === true
+        @test power_row["status"] == "fail"
+        @test power_row["n"] == 3
+        @test power_row["bias"] == 5.0 / 3.0
+        @test power_row["rmse"] == sqrt(25.0 / 3.0)
+        @test power_row["max_abs_error"] == 5.0
+        @test power_row["mean_abs_error"] == 5.0 / 3.0
+        @test power_row["reference_rms"] == sqrt(1400.0 / 3.0)
+        @test power_row["max_abs_reference"] == 30.0
+        @test power_row["relative_rmse"] == sqrt(25.0 / 3.0) / sqrt(1400.0 / 3.0)
+        @test power_row["tolerance"] == 3.0
+        @test power_row["atol"] == 0.0
+        @test power_row["rtol"] == 0.1
+
+        omega_row = report["channels"][3]
+        @test omega_row["passed"] === true
+        @test omega_row["status"] == "pass"
+        @test omega_row["relative_rmse"] == 0.0
+        @test omega_row["tolerance"] == 0.0
+
+        nonfinite_row = report["channels"][4]
+        @test nonfinite_row["passed"] === false
+        @test nonfinite_row["comparable"] === false
+        @test nonfinite_row["status"] == "non_finite"
+        @test nonfinite_row["reference_shape"] == [2]
+        @test nonfinite_row["candidate_shape"] == [2]
+        @test isnothing(nonfinite_row["rmse"])
+        @test isnothing(nonfinite_row["tolerance"])
+        @test nonfinite_row["atol"] == 0.0
+        @test nonfinite_row["rtol"] == 1.0e-6
+
+        missing_row = report["channels"][5]
+        @test missing_row["passed"] === false
+        @test missing_row["comparable"] === false
+        @test missing_row["status"] == "missing_reference_and_candidate"
+        @test isnothing(missing_row["reference_shape"])
+        @test isnothing(missing_row["candidate_shape"])
+        @test missing_row["n"] == 0
+        @test isnothing(missing_row["max_abs_error"])
+
+        written_report = OWENS.write_output_data_validation_report(
+            report_file,
+            reference_file,
+            candidate_file;
+            channels = ["t", "genPower", "OmegaHist", "OmegaDotHist", "genTorque"],
+            tolerances,
+            case_id = "validation-report-unit",
+            metadata = Dict(:source => :unit, :active => true),
+            created_at_utc = "2026-05-20T00:00:00.000Z",
+        )
+        loaded_report = OWENS.read_output_data_validation_report(report_file)
+        @test isfile(report_file)
+        @test written_report["schema_version"] == "owens-output-data-validation/v1"
+        @test loaded_report["schema_version"] == "owens-output-data-validation/v1"
+        @test loaded_report["case_id"] == "validation-report-unit"
+        @test loaded_report["status"] == "failed"
+        @test loaded_report["summary"]["channels_requested"] == 5
+        @test loaded_report["channels"][1]["status"] == "pass"
+        @test loaded_report["channels"][2]["status"] == "fail"
+        @test loaded_report["channels"][4]["status"] == "non_finite"
+
+        @test_throws KeyError OWENS.build_output_data_validation_report(
+            reference_file,
+            candidate_file;
+            channels = ["not_a_channel"],
+        )
+        @test_throws ArgumentError OWENS.build_output_data_validation_report(
+            reference_file,
+            candidate_file;
+            channels = ["t"],
+            tolerances = ["not" => "a dict"],
+        )
+        @test_throws ArgumentError OWENS.build_output_data_validation_report(
+            reference_file,
+            candidate_file;
+            channels = ["t"],
+            tolerances = Dict("t" => (; atol = -1.0)),
+        )
+        @test_throws ArgumentError OWENS.read_output_data_validation_report(
+            joinpath(dir, "missing.yml"),
+        )
+    end
+end


### PR DESCRIPTION
Adds YAML outputData validation report helpers around selected-channel metrics for GUI and regression dashboards. Depends on PR 146. Tests: julia --project=. test/test_validation_reports.jl; stacked cheap block covering run manifests, output data channels, validation reports, WindIO run spec, and VTK history output; JuliaFormatter file checks; git diff --check.