### PR TITLE
Add run manifest health checks

### DIFF
--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -36,6 +36,12 @@ Use `run_manifest_issues(manifest_or_path)` and
 retain the expected schema, file-record shape, byte counts, and SHA-256 digest
 format before a GUI or validation dashboard trusts them.
 
+Use `verify_file_provenance(record; root)` and
+`run_manifest_health(manifest_or_path)` to detect missing, modified, or
+malformed run artifacts from a manifest. `run_manifest_health` can also attach
+`output_data_summary` rows for healthy HDF5 outputs so a GUI can surface stale
+files and missing channel metadata in one pass.
+
 Use `build_output_data_validation_report(reference_path, candidate_path; ...)`
 and `write_output_data_validation_report(path, reference_path, candidate_path;
 ...)` to package selected-channel metric rows into a durable YAML artifact for
@@ -61,6 +67,8 @@ The public helpers are:
 - `write_windio_run_manifest(path, spec)`
 - `run_manifest_issues(manifest_or_path)`
 - `validate_run_manifest(manifest_or_path)`
+- `verify_file_provenance(record)`
+- `run_manifest_health(manifest_or_path)`
 - `build_output_data_validation_report(reference_path, candidate_path)`
 - `write_output_data_validation_report(path, reference_path, candidate_path)`
 - `read_output_data_validation_report(path)`

--- a/src/OWENS.jl
+++ b/src/OWENS.jl
@@ -79,6 +79,7 @@ include("io/windio_run_spec.jl")
 include("io/windio.jl")
 include("io/provenance.jl")
 include("io/validation_reports.jl")
+include("io/run_health.jl")
 
 # Preprocessing functionality
 include("preprocessing/gxbeam_conversion.jl")

--- a/src/io/run_health.jl
+++ b/src/io/run_health.jl
@@ -1,0 +1,212 @@
+export verify_file_provenance, run_manifest_health
+
+const RUN_MANIFEST_HEALTH_SCHEMA_VERSION = "owens-run-health/v1"
+
+"""
+    verify_file_provenance(record; root=pwd())
+
+Compare a manifest file record against the current file on disk. Relative paths
+are resolved against `root`; absolute paths are used as-is. The returned row is
+intended for project-health panels and reports missing, modified, or malformed
+artifacts without throwing for ordinary file drift.
+"""
+function verify_file_provenance(record; root::AbstractString = pwd())
+    issues = _file_provenance_record_issues(record)
+    if !isempty(issues)
+        return OrderedCollections.OrderedDict{String,Any}(
+            "status" => "invalid_record",
+            "issues" => issues,
+            "path" => _record_get_string(record, "path"),
+            "resolved_path" => nothing,
+            "role" => _record_get_string(record, "role"),
+            "expected_bytes" => _record_get_value(record, "bytes"),
+            "actual_bytes" => nothing,
+            "expected_sha256" => _record_get_string(record, "sha256"),
+            "actual_sha256" => nothing,
+        )
+    end
+
+    resolved_path = _resolve_manifest_file_path(record["path"], root)
+    if !isfile(resolved_path)
+        return OrderedCollections.OrderedDict{String,Any}(
+            "status" => "missing",
+            "issues" => String["missing file"],
+            "path" => string(record["path"]),
+            "resolved_path" => resolved_path,
+            "role" => get(record, "role", nothing),
+            "expected_bytes" => record["bytes"],
+            "actual_bytes" => nothing,
+            "expected_sha256" => record["sha256"],
+            "actual_sha256" => nothing,
+        )
+    end
+
+    actual_bytes = stat(resolved_path).size
+    actual_sha256 = file_sha256(resolved_path)
+    issues = String[]
+    if actual_bytes != record["bytes"]
+        push!(issues, "bytes mismatch")
+    end
+    if actual_sha256 != record["sha256"]
+        push!(issues, "sha256 mismatch")
+    end
+
+    return OrderedCollections.OrderedDict{String,Any}(
+        "status" => isempty(issues) ? "ok" : "modified",
+        "issues" => issues,
+        "path" => string(record["path"]),
+        "resolved_path" => resolved_path,
+        "role" => get(record, "role", nothing),
+        "expected_bytes" => record["bytes"],
+        "actual_bytes" => actual_bytes,
+        "expected_sha256" => record["sha256"],
+        "actual_sha256" => actual_sha256,
+    )
+end
+
+"""
+    run_manifest_health(manifest_or_path; root=nothing, summarize_outputs=true)
+
+Return a run health summary for a run manifest, including manifest schema
+diagnostics, current file-provenance status for inputs/outputs/generated files,
+and optional `outputData` channel summaries for healthy HDF5 outputs.
+"""
+run_manifest_health(path::AbstractString; kwargs...) =
+    run_manifest_health(read_run_manifest(path); manifest_path = path, kwargs...)
+
+function run_manifest_health(
+    manifest::AbstractDict;
+    manifest_path = nothing,
+    root = nothing,
+    summarize_outputs::Bool = true,
+)
+    manifest_issues = run_manifest_issues(manifest)
+    resolved_root = _manifest_health_root(manifest, manifest_path, root)
+
+    input_rows =
+        _manifest_section_health(manifest, "inputs", resolved_root; summarize = false)
+    output_rows = _manifest_section_health(
+        manifest,
+        "outputs",
+        resolved_root;
+        summarize = summarize_outputs,
+    )
+    generated_rows =
+        _manifest_section_health(manifest, "generated", resolved_root; summarize = false)
+    all_rows = vcat(input_rows, output_rows, generated_rows)
+    health_status =
+        isempty(manifest_issues) && all(row["status"] == "ok" for row in all_rows) ? "ok" :
+        "attention"
+
+    return OrderedCollections.OrderedDict{String,Any}(
+        "schema_version" => RUN_MANIFEST_HEALTH_SCHEMA_VERSION,
+        "status" => health_status,
+        "manifest_path" =>
+            isnothing(manifest_path) ? nothing : abspath(string(manifest_path)),
+        "root" => resolved_root,
+        "manifest_issues" => manifest_issues,
+        "summary" => OrderedCollections.OrderedDict{String,Any}(
+            "records" => length(all_rows),
+            "ok" => count(row -> row["status"] == "ok", all_rows),
+            "modified" => count(row -> row["status"] == "modified", all_rows),
+            "missing" => count(row -> row["status"] == "missing", all_rows),
+            "invalid_record" =>
+                count(row -> row["status"] == "invalid_record", all_rows),
+        ),
+        "inputs" => input_rows,
+        "outputs" => output_rows,
+        "generated" => generated_rows,
+    )
+end
+
+function _manifest_health_root(manifest::AbstractDict, manifest_path, root)
+    if !isnothing(root)
+        return abspath(string(root))
+    elseif haskey(manifest, "project_root") && manifest["project_root"] isa AbstractString
+        return abspath(manifest["project_root"])
+    elseif !isnothing(manifest_path)
+        return dirname(abspath(string(manifest_path)))
+    end
+
+    return pwd()
+end
+
+function _manifest_section_health(
+    manifest::AbstractDict,
+    section::AbstractString,
+    root::AbstractString;
+    summarize::Bool,
+)
+    records = get(manifest, section, OrderedCollections.OrderedDict{String,Any}[])
+    records isa AbstractVector || return OrderedCollections.OrderedDict{String,Any}[]
+
+    rows = OrderedCollections.OrderedDict{String,Any}[]
+    for record in records
+        row = verify_file_provenance(record; root)
+        if summarize &&
+           row["status"] == "ok" &&
+           endswith(lowercase(row["resolved_path"]), ".h5")
+            row["output_data_summary"] = _safe_output_data_summary(row["resolved_path"])
+        end
+        push!(rows, row)
+    end
+
+    return rows
+end
+
+function _safe_output_data_summary(path::AbstractString)
+    try
+        return [_validation_report_value(row) for row in output_data_summary(path)]
+    catch err
+        return OrderedCollections.OrderedDict{String,Any}(
+            "status" => "summary_error",
+            "message" => sprint(showerror, err),
+        )
+    end
+end
+
+function _file_provenance_record_issues(record)
+    issues = String[]
+    if !(record isa AbstractDict)
+        return String["record must be a dictionary"]
+    end
+
+    if !haskey(record, "path")
+        push!(issues, "path is required")
+    elseif !(record["path"] isa AbstractString)
+        push!(issues, "path must be a string")
+    end
+
+    if !haskey(record, "bytes")
+        push!(issues, "bytes is required")
+    elseif !_is_nonnegative_integer(record["bytes"])
+        push!(issues, "bytes must be a non-negative integer")
+    end
+
+    if !haskey(record, "sha256")
+        push!(issues, "sha256 is required")
+    elseif !_is_sha256_digest(record["sha256"])
+        push!(issues, "sha256 must be a lowercase 64-character SHA-256 digest")
+    end
+
+    if haskey(record, "role") && !(record["role"] isa AbstractString)
+        push!(issues, "role must be a string when present")
+    end
+
+    return issues
+end
+
+function _resolve_manifest_file_path(path::AbstractString, root::AbstractString)
+    return isabspath(path) ? normpath(path) : normpath(joinpath(root, path))
+end
+
+function _record_get_string(record, key::AbstractString)
+    record isa AbstractDict || return nothing
+    value = get(record, key, nothing)
+    return value isa AbstractString ? string(value) : nothing
+end
+
+function _record_get_value(record, key::AbstractString)
+    record isa AbstractDict || return nothing
+    return get(record, key, nothing)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,10 @@ end
     include("$path/test_run_manifest.jl")
 end
 
+@testset "Run Manifest Health" begin
+    include("$path/test_run_health.jl")
+end
+
 @testset "Output Data Channels" begin
     include("$path/test_output_data_channels.jl")
 end

--- a/test/test_run_health.jl
+++ b/test/test_run_health.jl
@@ -1,0 +1,197 @@
+using Test
+import HDF5
+import OWENS
+import OrderedCollections
+
+@testset "File provenance health rows" begin
+    mktempdir() do dir
+        input_file = joinpath(dir, "input.txt")
+        write(input_file, "alpha\n")
+        record = OWENS.file_provenance(input_file; root = dir, role = "input")
+
+        ok = OWENS.verify_file_provenance(record; root = dir)
+        @test collect(keys(ok)) == [
+            "status",
+            "issues",
+            "path",
+            "resolved_path",
+            "role",
+            "expected_bytes",
+            "actual_bytes",
+            "expected_sha256",
+            "actual_sha256",
+        ]
+        @test ok["status"] == "ok"
+        @test ok["issues"] == String[]
+        @test ok["path"] == "input.txt"
+        @test ok["resolved_path"] == abspath(input_file)
+        @test ok["role"] == "input"
+        @test ok["expected_bytes"] == 6
+        @test ok["actual_bytes"] == 6
+        @test ok["expected_sha256"] ==
+              "b6a98d9ce9a2d9149288fa3df42d377c3e42737afdcdaf714e33c0a100b51060"
+        @test ok["actual_sha256"] ==
+              "b6a98d9ce9a2d9149288fa3df42d377c3e42737afdcdaf714e33c0a100b51060"
+
+        write(input_file, "changed\n")
+        modified = OWENS.verify_file_provenance(record; root = dir)
+        @test modified["status"] == "modified"
+        @test modified["issues"] == ["bytes mismatch", "sha256 mismatch"]
+        @test modified["expected_bytes"] == 6
+        @test modified["actual_bytes"] == 8
+        @test modified["expected_sha256"] ==
+              "b6a98d9ce9a2d9149288fa3df42d377c3e42737afdcdaf714e33c0a100b51060"
+        @test modified["actual_sha256"] ==
+              "7f8b1dfc466b6249f06cbe55c9174df2578e7754da793fded244ef5cba2a38f1"
+
+        rm(input_file)
+        missing = OWENS.verify_file_provenance(record; root = dir)
+        @test missing["status"] == "missing"
+        @test missing["issues"] == ["missing file"]
+        @test missing["expected_bytes"] == 6
+        @test isnothing(missing["actual_bytes"])
+        @test isnothing(missing["actual_sha256"])
+
+        invalid = OWENS.verify_file_provenance(
+            Dict("path" => 42, "bytes" => true, "sha256" => "bad", "role" => 7);
+            root = dir,
+        )
+        @test invalid["status"] == "invalid_record"
+        @test invalid["issues"] == [
+            "path must be a string",
+            "bytes must be a non-negative integer",
+            "sha256 must be a lowercase 64-character SHA-256 digest",
+            "role must be a string when present",
+        ]
+        @test isnothing(invalid["path"])
+        @test isnothing(invalid["resolved_path"])
+        @test invalid["expected_bytes"] === true
+        @test invalid["expected_sha256"] == "bad"
+    end
+end
+
+@testset "Run manifest health summary" begin
+    mktempdir() do dir
+        input_file = joinpath(dir, "input.yml")
+        output_file = joinpath(dir, "output.h5")
+        generated_file = joinpath(dir, "generated.vtp")
+        manifest_file = joinpath(dir, "run_manifest.yml")
+
+        write(input_file, "input: unit\n")
+        HDF5.h5open(output_file, "w") do file
+            HDF5.write(file, "t", [1.0, 2.0, 3.0])
+        end
+        write(generated_file, "generated: unit\n")
+
+        manifest = OWENS.build_run_manifest(;
+            run_id = "health-unit",
+            run_name = "health unit",
+            project_root = dir,
+            solver = "unit-solver",
+            input_files = [input_file],
+            output_files = [output_file],
+            generated_files = [generated_file],
+            status = "complete",
+            created_at_utc = "2026-05-20T00:00:00.000Z",
+        )
+        OWENS.write_run_manifest(manifest_file, manifest)
+
+        health = OWENS.run_manifest_health(manifest)
+        @test collect(keys(health)) == [
+            "schema_version",
+            "status",
+            "manifest_path",
+            "root",
+            "manifest_issues",
+            "summary",
+            "inputs",
+            "outputs",
+            "generated",
+        ]
+        @test health["schema_version"] == "owens-run-health/v1"
+        @test health["status"] == "ok"
+        @test isnothing(health["manifest_path"])
+        @test health["root"] == abspath(dir)
+        @test health["manifest_issues"] == String[]
+        @test health["summary"] == OrderedCollections.OrderedDict{String,Any}(
+            "records" => 3,
+            "ok" => 3,
+            "modified" => 0,
+            "missing" => 0,
+            "invalid_record" => 0,
+        )
+        @test length(health["inputs"]) == 1
+        @test length(health["outputs"]) == 1
+        @test length(health["generated"]) == 1
+        @test health["inputs"][1]["status"] == "ok"
+        @test health["outputs"][1]["status"] == "ok"
+        @test health["generated"][1]["status"] == "ok"
+        @test haskey(health["outputs"][1], "output_data_summary")
+        @test length(health["outputs"][1]["output_data_summary"]) == 41
+        @test health["outputs"][1]["output_data_summary"][1]["name"] == "t"
+        @test health["outputs"][1]["output_data_summary"][1]["present"] === true
+        @test health["outputs"][1]["output_data_summary"][1]["shape"] == [3]
+        @test health["outputs"][1]["output_data_summary"][1]["attr_mismatches"] == [
+            "missing:owens_channel_name",
+            "missing:units",
+            "missing:dimensions",
+            "missing:frame",
+            "missing:association",
+            "missing:source",
+            "missing:sign_convention",
+            "missing:description",
+        ]
+
+        loaded_health = OWENS.run_manifest_health(manifest_file)
+        @test loaded_health["status"] == "ok"
+        @test loaded_health["manifest_path"] == abspath(manifest_file)
+        @test loaded_health["summary"] == health["summary"]
+
+        no_output_summary = OWENS.run_manifest_health(manifest; summarize_outputs = false)
+        @test no_output_summary["outputs"][1]["status"] == "ok"
+        @test !haskey(no_output_summary["outputs"][1], "output_data_summary")
+
+        stale_root_manifest = deepcopy(manifest)
+        stale_root_manifest["project_root"] = joinpath(dir, "stale")
+        stale_health = OWENS.run_manifest_health(stale_root_manifest)
+        @test stale_health["status"] == "attention"
+        @test stale_health["summary"] == OrderedCollections.OrderedDict{String,Any}(
+            "records" => 3,
+            "ok" => 0,
+            "modified" => 0,
+            "missing" => 3,
+            "invalid_record" => 0,
+        )
+        override_health = OWENS.run_manifest_health(stale_root_manifest; root = dir)
+        @test override_health["status"] == "ok"
+        @test override_health["root"] == abspath(dir)
+        @test override_health["summary"] == health["summary"]
+
+        write(input_file, "input: changed\n")
+        rm(generated_file)
+        drift_health = OWENS.run_manifest_health(manifest)
+        @test drift_health["status"] == "attention"
+        @test drift_health["summary"] == OrderedCollections.OrderedDict{String,Any}(
+            "records" => 3,
+            "ok" => 1,
+            "modified" => 1,
+            "missing" => 1,
+            "invalid_record" => 0,
+        )
+        @test drift_health["inputs"][1]["status"] == "modified"
+        @test drift_health["inputs"][1]["issues"] == ["bytes mismatch", "sha256 mismatch"]
+        @test drift_health["outputs"][1]["status"] == "ok"
+        @test drift_health["generated"][1]["status"] == "missing"
+
+        invalid_manifest = deepcopy(manifest)
+        push!(
+            invalid_manifest["inputs"],
+            Dict("path" => 42, "bytes" => true, "sha256" => "bad"),
+        )
+        invalid_health = OWENS.run_manifest_health(invalid_manifest)
+        @test invalid_health["status"] == "attention"
+        @test invalid_health["summary"]["invalid_record"] == 1
+        @test invalid_health["inputs"][2]["status"] == "invalid_record"
+        @test invalid_health["manifest_issues"][1] == "inputs[2].path must be a string"
+    end
+end


### PR DESCRIPTION
Adds file-provenance and run-manifest health helpers for GUI/project health panels, including stale/missing/modified artifact detection and optional outputData HDF5 summaries. Depends on PR 147. Tests: julia --project=. test/test_run_health.jl; stacked cheap block covering run manifests, run health, output data channels, validation reports, WindIO run spec, and VTK history output; JuliaFormatter file checks; git diff --check.