### PR TITLE
Map aerodynamic M25 into structural loads

### DIFF
--- a/src/runtime/AeroMapping.jl
+++ b/src/runtime/AeroMapping.jl
@@ -97,6 +97,7 @@ function mapACDMS(
     outputfile = nothing,
     offsetmomentarm = 0.0,
 )
+    aero_result = advanceTurb(t; azi = azi_j, alwaysrecalc) #add 3pi/2 to align aero with structural azimuth
     CP,
     Rp,
     Tp,
@@ -124,7 +125,8 @@ function mapACDMS(
     M_addedmass_Np,
     M_addedmass_Tp,
     F_addedmass_Np,
-    F_addedmass_Tp = advanceTurb(t; azi = azi_j, alwaysrecalc) #add 3pi/2 to align aero with structural azimuth
+    F_addedmass_Tp = aero_result
+    aero_M25 = length(aero_result) > 28 ? aero_result[end] : nothing
 
     NBlade = length(Rp[:, 1, 1])
     Nslices = length(Rp[1, :, 1])
@@ -149,7 +151,11 @@ function mapACDMS(
             for islice = 1:Nslices
                 N[jbld, iTS, islice] = Rp[jbld, islice, t_idx] #Normal force on the structure is inward, OWENSAero normal is inward positive #we multiply by cos(delta) to go from force per height to force per span, and then divide by cos(delta) to go from radial to normal, so they cancel
                 T[jbld, iTS, islice] = -Tp[jbld, islice, t_idx]*cos(delta[jbld, islice]) ##Tangential force on the structure is against turbine rotation, OWENSAero tangential is with rotation positive # multiply by delta to convert from force per height to force per span
-                M25[jbld, iTS, islice] = Rp[jbld, islice, t_idx]*offsetmomentarm #0.0#M25perSpan[index]
+                M25[jbld, iTS, islice] =
+                    (
+                        aero_M25 === nothing ? zero(Rp[jbld, islice, t_idx]) :
+                        aero_M25[jbld, islice, t_idx]
+                    ) + Rp[jbld, islice, t_idx]*offsetmomentarm
                 X[jbld, iTS, islice] = Xp[jbld, islice, t_idx]#*cos(-azi_j) + Yp[jbld,islice,t_idx]*sin(-azi_j) #*cos(delta[jbld,islice]) 
                 Y[jbld, iTS, islice] = Yp[jbld, islice, t_idx]#*sin(-azi_j) + Yp[jbld,islice,t_idx]*cos(-azi_j)#*cos(delta[jbld,islice]) 
                 Z[jbld, iTS, islice] = Zp[jbld, islice, t_idx]#*cos(delta[jbld,islice])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,10 @@ end
     include("$path/test_validation_reports.jl")
 end
 
+@testset "Aero Mapping" begin
+    include("$path/test_aero_mapping.jl")
+end
+
 @testset "WindIO Run Spec" begin
     include("$path/test_windio_run_spec.jl")
 end

--- a/test/test_aero_mapping.jl
+++ b/test/test_aero_mapping.jl
@@ -1,0 +1,82 @@
+using Test
+import OWENS
+import OWENSFEA
+
+@testset "AC/DMS aerodynamic pitching moment mapping" begin
+    mesh = OWENSFEA.Mesh(
+        [1, 2],
+        1,
+        2,
+        [0.0, 0.0],
+        [0.0, 0.0],
+        [0.0, 1.0],
+        [1],
+        [1 2],
+        [0],
+        [2],
+        [0.5 0.5],
+        [1 2],
+        [1 1],
+        0,
+        1,
+        zeros(3),
+        zeros(3),
+    )
+    el = OWENSFEA.El(
+        [(twist = [0.0, 0.0],)],
+        [1.0],
+        [0.0],
+        [0.0],
+        [0.0],
+        [1.0],
+    )
+
+    function advance_stub(t; azi, alwaysrecalc)
+        nblade = 1
+        nslices = 3
+        nsteps = 1
+        blade_slice_step = zeros(nblade, nslices, nsteps)
+        slice_step = zeros(nslices, nsteps)
+        step = zeros(nsteps)
+        return (
+            0.0,
+            blade_slice_step,
+            blade_slice_step,
+            blade_slice_step,
+            blade_slice_step,
+            slice_step,
+            slice_step,
+            blade_slice_step,
+            slice_step,
+            step,
+            nsteps,
+            step,
+            step,
+            step,
+            step,
+            step,
+            step,
+            step,
+            step,
+            step,
+            [0.25, 0.5, 0.75],
+            zeros(nblade, nslices),
+            blade_slice_step,
+            blade_slice_step,
+            step,
+            slice_step,
+            slice_step,
+            slice_step,
+            slice_step,
+            zeros(nslices, nsteps, 3),
+            slice_step,
+            fill(12.0, nblade, nslices, nsteps),
+        )
+    end
+
+    forces, dofs = OWENS.mapACDMS(0.0, 0.0, mesh, el, advance_stub)
+
+    @test dofs == collect(1:12)
+    @test forces[1:3, 1] == zeros(3)
+    @test forces[10, 1] ≈ 6.0 atol = 1e-12
+end


### PR DESCRIPTION
## Summary
- consume the aerodynamic `M25` channel returned by OWENSAero in `mapACDMS`
- preserve the existing `Rp * offsetmomentarm` contribution by adding it to aerodynamic pitching moment
- add a focused mapping regression for the structural DOF-4 load path

## Issue
Addresses sandialabs/OWENSAero.jl#15 from the OWENS structural-coupling side.

## Verification
- `julia --project=. test/test_aero_mapping.jl`