### PR TITLE
Pin section property reader offsets

### DIFF
--- a/src/io/fileio.jl
+++ b/src/io/fileio.jl
@@ -1133,6 +1133,11 @@ object.
 
 #Output
 * `el::OWENSFEA.El`:       see OWENSFEA.El    element data object
+
+The legacy `.el` format stores flapwise and edgewise elastic-axis offsets in
+columns 16 and 17. `readElementData` currently uses column 17 as
+`SectionPropsArray.a`, then converts it to a semichord fraction after the chord
+is read from blade data. Column 16 is not represented in `SectionPropsArray`.
 """
 function readElementData(numElements, elfile, ortfile, bladeData_struct)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,10 @@ end
     include("$path/test_aero_mapping.jl")
 end
 
+@testset "Section Property Reader" begin
+    include("$path/test_section_property_reader.jl")
+end
+
 @testset "WindIO Run Spec" begin
     include("$path/test_windio_run_spec.jl")
 end

--- a/test/test_section_property_reader.jl
+++ b/test/test_section_property_reader.jl
@@ -1,0 +1,42 @@
+using Test
+import OWENS
+
+@testset "Element reader section-property conventions" begin
+    mktempdir() do dir
+        elfile = joinpath(dir, "section.el")
+        ortfile = joinpath(dir, "section.ort")
+
+        write(
+            elfile,
+            join(
+                [
+                    "0.0 0.4 1.0 2.0 3.0 4.0 5.0 6.0 0.7 8.0 9.0 0.0 0.0 0.11 0.12 9.0 0.25",
+                    "1.0 0.6 1.5 2.5 3.5 4.5 5.5 6.5 0.8 8.5 9.5 0.0 0.0 0.21 0.22 11.0 0.50",
+                ],
+                "\n",
+            ) * "\n",
+        )
+        write(ortfile, "1 10.0 20.0 30.0 4.0\n")
+
+        blade_remaining = zeros(2, 12)
+        blade_remaining[:, 10] .= [4.0, 6.0]
+        blade_remaining[:, 12] .= [5.0, 7.0]
+        blade_data =
+            OWENS.BladeData(1, [1, 1], [0.0, 1.0], [1, 2], [1, -1], blade_remaining)
+
+        el = OWENS.readElementData(1, elfile, ortfile, blade_data)
+
+        @test el.elLen == [4.0]
+        @test el.psi == [10.0]
+        @test el.theta == [20.0]
+        @test el.roll == [30.0]
+
+        props = el.props[1]
+        @test props.zcm == [0.11, 0.21]
+        @test props.ycm == [0.12, 0.22]
+        @test props.b == [2.0, 3.0]
+        @test props.a0 == [5.0, 7.0]
+        @test props.ac ≈ [0.2, -0.2]
+        @test props.a ≈ [0.25 / 2.0 - 0.5, 0.50 / 3.0 - 0.5]
+    end
+end


### PR DESCRIPTION
## Summary
- document the legacy `.el` column convention for elastic-axis offsets in `readElementData`
- add a minimal reader fixture that pins current `a`, `a0`, chord, aerodynamic-center, center-of-mass, and orientation mapping
- establish a baseline for OWENS.jl #34 before changing or extending section-property fields

## Tests
- `julia --project=. test/test_section_property_reader.jl`
- `git diff --check`

Refs #34