### PR TITLE
Reject legacy Time Dean option

### DIFF
--- a/src/core/ModelingOptions.jl
+++ b/src/core/ModelingOptions.jl
@@ -1,6 +1,18 @@
 using OrderedCollections: OrderedDict
 using YAML
 
+function _reject_time_dean_option(value, field_name)
+    if value isa AbstractString &&
+       uppercase(replace(strip(value), r"[\s_-]"=>"")) in ("TD", "TIMEDEAN", "DEAN")
+        throw(
+            ArgumentError(
+                "Dean time stepping (`TD`) is no longer supported through OWENS `$field_name`; use `TNB`, `ROM`, or `GX` instead.",
+            ),
+        )
+    end
+    return value
+end
+
 export MasterInput,
     OWENS_Options,
     DLC_Options,
@@ -161,6 +173,8 @@ function MasterInput(;
     NuMad_geom_xlscsv_file_strut = "$module_path/../test/examples/data/NuMAD_Geom_SNL_5MW_Struts.csv",
     NuMad_mat_xlscsv_file_strut = "$module_path/../test/examples/data/NuMAD_Materials_SNL_5MW.csv",
 )
+    structuralModel = _reject_time_dean_option(structuralModel, "structuralModel")
+
     return MasterInput(
         analysisType,
         turbineType,
@@ -240,6 +254,7 @@ function MasterInput(yamlInputfile)
 
     structuralParameters = yamlInput["structuralParameters"]
     structuralModel = structuralParameters["structuralModel"]
+    structuralModel = _reject_time_dean_option(structuralModel, "structuralModel")
     ntelem = structuralParameters["ntelem"]
     nbelem = structuralParameters["nbelem"]
     ncelem = structuralParameters["ncelem"]
@@ -348,7 +363,10 @@ mutable struct OWENS_Options
         new(
             get(dict_in, :analysisType, "Unsteady"), # Unsteady, DLC, Campbell, todo: steady, flutter may be re-activated in the future.
             get(dict_in, :AeroModel, "DMS"), # OWENSAero model "DMS" for double multiple streamtube or "AC" for actuator cylinder, or "AD" for aerodyn
-            get(dict_in, :structuralModel, "TNB"), # Structural models available: TNB full timoshenko beam elements with time newmark beta time stepping, ROM reduced order modal model of the timoshenko elements, GX with GXBeam's methods for geometrically exact beam theory and more efficient methods and time stepping
+            _reject_time_dean_option(
+                get(dict_in, :structuralModel, "TNB"),
+                "structuralModel",
+            ), # Structural models available: TNB full timoshenko beam elements with time newmark beta time stepping, ROM reduced order modal model of the timoshenko elements, GX with GXBeam's methods for geometrically exact beam theory and more efficient methods and time stepping
             get(dict_in, :controlStrategy, "normal"), # should be in WindIO?- yes, 
             get(dict_in, :numTS, 10), # number of time steps TODO: change to sim time and make this derived
             get(dict_in, :delta_t, 0.05), # time step in seconds

--- a/src/core/structs.jl
+++ b/src/core/structs.jl
@@ -98,7 +98,7 @@ Model inputs for OWENS coupled analysis, struct
 
 # Inputs
 * `verbosity::int`: output verbosity where 0 is nothing, 1 is warnings, 2 is summary outputs, 3 is detailed outputs, and 4 is everything
-* `analysisType::string`: Newmark Beta time stepping "TNB", Dean time stepping "TD", modal "M"
+* `analysisType::string`: Newmark Beta time stepping "TNB", reduced-order model "ROM", GXBeam "GX", or modal "M"
 * `turbineStartup::int`: 1 forced start-up using generator as motor, 2 self-starting mode, 0 specified rotor speed mode")
 * `usingRotorSpeedFunction::bool`: use user specified rotor speed profile function
 * `tocp::Array{<:float}`: = time points for rotor speed profile (s)
@@ -186,6 +186,7 @@ function Inputs(;
     TOL = 1e-4,
     MAXITER = 20,
 )
+    analysisType = _reject_time_dean_option(analysisType, "analysisType")
 
     return Inputs(
         verbosity,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ end
     include("$path/test_initial_conditions.jl")
 end
 
+@testset "Time Dean Option" begin
+    include("$path/test_time_dean_option.jl")
+end
+
 @testset "MoorDyn Buffer Helpers" begin
     include("$path/test_moordyn_buffers.jl")
 end

--- a/test/test_time_dean_option.jl
+++ b/test/test_time_dean_option.jl
@@ -1,0 +1,25 @@
+using Test
+using OWENS
+using OrderedCollections: OrderedDict
+
+@testset "legacy Time Dean option is rejected" begin
+    @test_throws ArgumentError OWENS.Inputs(; analysisType = "TD")
+    @test_throws ArgumentError OWENS.Inputs(; analysisType = "time_dean")
+    @test_throws ArgumentError OWENS.MasterInput(; structuralModel = "TD")
+    @test_throws ArgumentError OWENS.OWENS_Options(
+        OrderedDict{Symbol,Any}(:structuralModel=>"TD"),
+    )
+
+    mktempdir() do dir
+        options_file = joinpath(dir, "modeling_options.yml")
+        write(
+            options_file,
+            """
+            OWENS_Options:
+              structuralModel: TD
+            """,
+        )
+
+        @test_throws ArgumentError OWENS.ModelingOptions(options_file)
+    end
+end


### PR DESCRIPTION
## Summary
- reject legacy `TD` / Time Dean structural-model values at OWENS configuration boundaries
- remove the OWENS `Inputs` doc reference that advertised Dean time stepping
- add a regression covering direct `Inputs`, `MasterInput`, `OWENS_Options`, and YAML `ModelingOptions` paths

Closes #36

## Tests
- `julia --project=. test/test_time_dean_option.jl`
- `git diff --check`