### PR TITLE
Read section elastic-axis offsets

### DIFF
--- a/src/io/fileio.jl
+++ b/src/io/fileio.jl
@@ -1137,7 +1137,8 @@ object.
 The legacy `.el` format stores flapwise and edgewise elastic-axis offsets in
 columns 16 and 17. `readElementData` currently uses column 17 as
 `SectionPropsArray.a`, then converts it to a semichord fraction after the chord
-is read from blade data. Column 16 is not represented in `SectionPropsArray`.
+is read from blade data. The raw columns are also passed through as
+`SectionPropsArray.flapwiseEAOffset` and `SectionPropsArray.edgewiseEAOffset`.
 """
 function readElementData(numElements, elfile, ortfile, bladeData_struct)
 
@@ -1195,6 +1196,8 @@ function readElementData(numElements, elfile, ortfile, bladeData_struct)
         zcm = [data1[14], data2[14]]
         ycm = [data1[15], data2[15]]
         a = [data1[17], data2[17]]
+        flapwiseEAOffset = [data1[16], data2[16]]
+        edgewiseEAOffset = [data1[17], data2[17]]
 
         #coupling factors
         EIyz = [0.0, 0.0]
@@ -1234,6 +1237,8 @@ function readElementData(numElements, elfile, ortfile, bladeData_struct)
             a0,
             aeroCenterOffset,
         )
+        sectionPropsArray[i].flapwiseEAOffset = flapwiseEAOffset
+        sectionPropsArray[i].edgewiseEAOffset = edgewiseEAOffset
 
     end
     close(fid) #close element file

--- a/test/test_section_property_reader.jl
+++ b/test/test_section_property_reader.jl
@@ -34,6 +34,8 @@ import OWENS
         props = el.props[1]
         @test props.zcm == [0.11, 0.21]
         @test props.ycm == [0.12, 0.22]
+        @test props.flapwiseEAOffset == [9.0, 11.0]
+        @test props.edgewiseEAOffset == [0.25, 0.50]
         @test props.b == [2.0, 3.0]
         @test props.a0 == [5.0, 7.0]
         @test props.ac ≈ [0.2, -0.2]


### PR DESCRIPTION
## Summary
- pass legacy .el column 16 into SectionPropsArray.flapwiseEAOffset
- pass legacy .el column 17 into SectionPropsArray.edgewiseEAOffset while preserving the existing a conversion
- extend the section-property reader fixture to cover both raw offset fields

## Tests
- julia --project=. test/test_section_property_reader.jl
- git diff --check

Closes #34