### PR TITLE
Hook up strut safety factor postprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OWENS is primarily developed with the support of the U.S. Department of Energy a
 
 
 ## Installation
-For Julia 1.11+.  For new Julia users, developer install, and those wishing to use Julia 1.10 and below, see the In-Depth Installation page in the docs.
+For Julia 1.11+. If dependency resolution reports that `OWENSOpenFASTWrappers` has no known versions, use the URL-dependency fallback on the In-Depth Installation page.
 
 ```julia
 using Pkg

--- a/docs/src/indepth_installation.md
+++ b/docs/src/indepth_installation.md
@@ -225,10 +225,14 @@ rm("delim_file.txt") # julia's function that does the same thing
 
 ## OWENS Installation for Julia 1.11+
 
+This one-line install works when the dependency chain can be resolved from the registry and package sources:
+
 ```julia
 using Pkg
 Pkg.add(PackageSpec(url="https://github.com/sandialabs/OWENS.jl.git"))
 ```
+
+If resolution fails with `OWENSOpenFASTWrappers has no known versions`, use the URL-dependency fallback below. That error means the OpenFAST wrapper dependency chain is not fully available from the registry being used by the Julia package manager.
 
 Note that there are many packages used in the examples.  While they are installed within the OWENS.jl environment, if you want to additionally install them in your 1.11+ environment where you will likely be running from:
 ```julia
@@ -247,8 +251,8 @@ Pkg.add("PyPlot") #Note, this will take a while (maybe 10 min depending on your 
 # Pkg.add("PyPlot")
 ```
 
-## OWENS Installation for Julia 1.10 and older (down to 1.6)
-These steps require a secure download, such as through the SSH keys detailed above, to avoid man-in-the-middle attacks. 
+## OWENS URL-Dependency Fallback for Julia 1.6+
+Use this fallback for Julia 1.10 and older, or for Julia 1.11+ environments where the one-line URL install cannot resolve the unregistered OWENS OpenFAST dependencies. These steps require a secure download, such as through the SSH keys detailed above, to avoid man-in-the-middle attacks.
 ```julia
 
 using Pkg

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,7 @@ This package is for experienced researchers and analyists with both software and
 OWENS is an ontology, or way of coupling modular aerodynamic, structural, hydrodynamic, and controls packages.  It was originally based on the structural dynamics solver by Brian Owens (see dissertation: http://hdl.handle.net/1969.1/151813). However, it has been rewritten into the Julia programming language, modularized, and many of the issues related to aerodynamic coupling and floating dynamics solved, with extensive expansion into other areas and features to provide a seamless and automated process that takes in high level design details and does all of the preprocessing, running, and post processing that is normally done under different roofs or by different manual processes.  This was done with the intent of enabling fast, parametric design.  We have many of the modules propogating automatic gradients, however this is still a future challenge to solve well. 
 
 ## Installation
-For Julia 1.11+.  For new Julia users, developer install, and those wishing to use Julia 1.10 and below, see the In-Depth Installation page.
+For Julia 1.11+. If dependency resolution reports that `OWENSOpenFASTWrappers` has no known versions, use the URL-dependency fallback on the In-Depth Installation page.
 
 ```julia
 using Pkg

--- a/examples/SNL34m/Example34mHVAWTConfiguration.jl
+++ b/examples/SNL34m/Example34mHVAWTConfiguration.jl
@@ -114,7 +114,9 @@ mymesh,myel,myort,myjoint,sectionPropsArray,mass_twr, mass_bld,
 stiff_twr, stiff_bld,bld_precompinput,
 bld_precompoutput,plyprops_bld,numadIn_bld,lam_U_bld,lam_L_bld,
 twr_precompinput,twr_precompoutput,plyprops_twr,numadIn_twr,lam_U_twr,lam_L_twr,aeroForces,deformAero,
-mass_breakout_blds,mass_breakout_twr,system, assembly, sections,AD15bldNdIdxRng, AD15bldElIdxRng = OWENS.setupOWENS(OWENSAero,path;
+mass_breakout_blds,mass_breakout_twr,system, assembly, sections,AD15bldNdIdxRng, AD15bldElIdxRng,
+custom_mesh_outputs, stiff_array, mass_array, strut_precompinput, strut_precompoutput,
+plyprops_strut, numadIn_strut, lam_U_strut, lam_L_strut = OWENS.setupOWENS(OWENSAero,path;
     rho,
     Nslices,
     ntheta,
@@ -389,7 +391,8 @@ composite_station_idx_U_bld = [1,6,3,2,5],
 composite_station_name_U_bld = ["Leading Edge","Trailing Edge","Spar Cap","Front Panel","Rear Panel"],
 composite_station_idx_L_bld = [1,6,3,2,5],
 composite_station_name_L_bld = ["Leading Edge","Trailing Edge","Spar Cap","Front Panel","Rear Panel"],
-Twr_LE_U_idx=1,Twr_LE_L_idx=1,AD15bldNdIdxRng, AD15bldElIdxRng ) #TODO: add in ability to have material safety factors and load safety factors
+Twr_LE_U_idx=1,Twr_LE_L_idx=1,AD15bldNdIdxRng, AD15bldElIdxRng,
+strut_precompoutput, strut_precompinput, plyprops_strut, numadIn_strut, lam_U_strut, lam_L_strut) #TODO: add in ability to have material safety factors and load safety factors
 
 nothing
 

--- a/examples/SNL34m/SNL34mVAWTNormalOperation.jl
+++ b/examples/SNL34m/SNL34mVAWTNormalOperation.jl
@@ -118,7 +118,9 @@ mymesh,myel,myort,myjoint,sectionPropsArray,mass_twr, mass_bld,
 stiff_twr, stiff_bld,bld_precompinput,
 bld_precompoutput,plyprops_bld,numadIn_bld,lam_U_bld,lam_L_bld,
 twr_precompinput,twr_precompoutput,plyprops_twr,numadIn_twr,lam_U_twr,lam_L_twr,aeroForces,deformAero,
-mass_breakout_blds,mass_breakout_twr,system, assembly, sections,AD15bldNdIdxRng, AD15bldElIdxRng = OWENS.setupOWENS(OWENSAero,path;
+mass_breakout_blds,mass_breakout_twr,system, assembly, sections,AD15bldNdIdxRng, AD15bldElIdxRng,
+custom_mesh_outputs, stiff_array, mass_array, strut_precompinput, strut_precompoutput,
+plyprops_strut, numadIn_strut, lam_U_strut, lam_L_strut = OWENS.setupOWENS(OWENSAero,path;
     rho,
     Nslices,
     ntheta,
@@ -531,7 +533,8 @@ composite_station_idx_U_bld = [1,6,3,2,5],
 composite_station_name_U_bld = ["Leading Edge","Trailing Edge","Spar Cap","Front Panel","Rear Panel"],
 composite_station_idx_L_bld = [1,6,3,2,5],
 composite_station_name_L_bld = ["Leading Edge","Trailing Edge","Spar Cap","Front Panel","Rear Panel"],
-Twr_LE_U_idx=1,Twr_LE_L_idx=1,AD15bldNdIdxRng, AD15bldElIdxRng ) #TODO: add in ability to have material safety factors and load safety factors
+Twr_LE_U_idx=1,Twr_LE_L_idx=1,AD15bldNdIdxRng, AD15bldElIdxRng,
+strut_precompoutput, strut_precompinput, plyprops_strut, numadIn_strut, lam_U_strut, lam_L_strut) #TODO: add in ability to have material safety factors and load safety factors
 
 nothing
 

--- a/examples/helical_riverine/helical_riverine_driver.jl
+++ b/examples/helical_riverine/helical_riverine_driver.jl
@@ -83,7 +83,9 @@ mymesh,myel,myort,myjoint,sectionPropsArray,mass_twr, mass_bld,
 stiff_twr, stiff_bld,bld_precompinput,
 bld_precompoutput,plyprops_bld,numadIn_bld,lam_U_bld,lam_L_bld,
 twr_precompinput,twr_precompoutput,plyprops_twr,numadIn_twr,lam_U_twr,lam_L_twr,aeroForces,deformAero,
-mass_breakout_blds,mass_breakout_twr,system, assembly, sections,AD15bldNdIdxRng, AD15bldElIdxRng  = OWENS.setupOWENS(OWENSAero,path;
+mass_breakout_blds,mass_breakout_twr,system, assembly, sections,AD15bldNdIdxRng, AD15bldElIdxRng,
+custom_mesh_outputs, stiff_array, mass_array, strut_precompinput, strut_precompoutput,
+plyprops_strut, numadIn_strut, lam_U_strut, lam_L_strut  = OWENS.setupOWENS(OWENSAero,path;
     rho, #windio
     Nslices, #modeling options
     ntheta, #modeling options
@@ -289,7 +291,8 @@ composite_station_idx_U_bld = [1,6,3,2,5],
 composite_station_name_U_bld = ["Leading Edge","Trailing Edge","Spar Cap","Front Panel","Rear Panel"],
 composite_station_idx_L_bld = [1,6,3,2,5],
 composite_station_name_L_bld = ["Leading Edge","Trailing Edge","Spar Cap","Front Panel","Rear Panel"],
-Twr_LE_U_idx=1,Twr_LE_L_idx=1,AD15bldNdIdxRng,AD15bldElIdxRng) #TODO: add in ability to have material safety factors and load safety factors
+Twr_LE_U_idx=1,Twr_LE_L_idx=1,AD15bldNdIdxRng,AD15bldElIdxRng,
+strut_precompoutput, strut_precompinput, plyprops_strut, numadIn_strut, lam_U_strut, lam_L_strut) #TODO: add in ability to have material safety factors and load safety factors
 
 nothing
 

--- a/examples/literate/C_customizablePreprocessing.jl
+++ b/examples/literate/C_customizablePreprocessing.jl
@@ -786,7 +786,7 @@ if run_full_example
     composite_station_idx_L_bld = [1,6,3,2,5],
     composite_station_name_L_bld = ["Leading Edge","Trailing Edge","Spar Cap","Front Panel","Rear Panel"],
     Twr_LE_U_idx=1,Twr_LE_L_idx=1,
-    AD15bldNdIdxRng,AD15bldElIdxRng,strut_precompoutput=nothing,strut_precompinput,plyprops_strut,numadIn_strut,lam_U_strut,lam_L_strut) #TODO: add in ability to have material safety factors and load safety factors
+    AD15bldNdIdxRng,AD15bldElIdxRng,strut_precompoutput,strut_precompinput,plyprops_strut,numadIn_strut,lam_U_strut,lam_L_strut) #TODO: add in ability to have material safety factors and load safety factors
 end
 
 nothing

--- a/examples/literate/E_RM2_Medium.jl
+++ b/examples/literate/E_RM2_Medium.jl
@@ -143,7 +143,9 @@ iTSR = 1
     stiff_twr, stiff_bld,bld_precompinput,
     bld_precompoutput,plyprops_bld,numadIn_bld,lam_U_bld,lam_L_bld,
     twr_precompinput,twr_precompoutput,plyprops_twr,numadIn_twr,lam_U_twr,lam_L_twr,aeroForces,deformAero,
-    mass_breakout_blds,mass_breakout_twr,system,assembly,sections,AD15bldNdIdxRng, AD15bldElIdxRng = OWENS.setupOWENS(OWENSAero,path;
+    mass_breakout_blds,mass_breakout_twr,system,assembly,sections,AD15bldNdIdxRng, AD15bldElIdxRng,
+    custom_mesh_outputs, stiff_array, mass_array, strut_precompinput, strut_precompoutput,
+    plyprops_strut, numadIn_strut, lam_U_strut, lam_L_strut = OWENS.setupOWENS(OWENSAero,path;
         rho=fluid_density,
         mu=fluid_dyn_viscosity,
         Nslices,
@@ -323,7 +325,8 @@ iTSR = 1
         mymesh,myel,myort,number_of_blades,epsilon_x_hist,kappa_y_hist,kappa_z_hist,epsilon_z_hist,
         kappa_x_hist,epsilon_y_hist;verbosity, #Verbosity 0:no printing, 1: summary, 2: summary and spanwise worst safety factor
         Twr_LE_U_idx=1,Twr_LE_L_idx=1,delta_t,
-        AD15bldNdIdxRng,AD15bldElIdxRng,strut_precompoutput=nothing)
+        AD15bldNdIdxRng,AD15bldElIdxRng,strut_precompoutput,strut_precompinput,
+        plyprops_strut,numadIn_strut,lam_U_strut,lam_L_strut)
 
         OWENS.outputData(;mymesh,inputs,t,aziHist,OmegaHist,OmegaDotHist,gbHist,gbDotHist,gbDotDotHist,FReactionHist,genTorque,genPower,torqueDriveShaft,uHist,uHist_prp,epsilon_x_hist,epsilon_y_hist,epsilon_z_hist,kappa_x_hist,kappa_y_hist,kappa_z_hist,FTwrBsHist,massOwens,stress_U,SF_ult_U,SF_buck_U,stress_L,SF_ult_L,SF_buck_L,stress_TU,SF_ult_TU,SF_buck_TU,stress_TL,SF_ult_TL,SF_buck_TL,topstrainout_blade_U,topstrainout_blade_L,topstrainout_tower_U,topstrainout_tower_L,topDamage_blade_U,topDamage_blade_L,topDamage_tower_U,topDamage_tower_L)
     end

--- a/src/io/fileio.jl
+++ b/src/io/fileio.jl
@@ -1496,6 +1496,12 @@ function outputData(;
     topDamage_blade_L = "not saved",
     topDamage_tower_U = "not saved",
     topDamage_tower_L = "not saved",
+    stress_U_strut = nothing,
+    SF_ult_U_strut = nothing,
+    SF_buck_U_strut = nothing,
+    stress_L_strut = nothing,
+    SF_ult_L_strut = nothing,
+    SF_buck_L_strut = nothing,
     ofastformat = false,
 )
 
@@ -1547,6 +1553,18 @@ function outputData(;
             HDF5.write(file, "topDamage_blade_L", topDamage_blade_L)
             HDF5.write(file, "topDamage_tower_U", topDamage_tower_U)
             HDF5.write(file, "topDamage_tower_L", topDamage_tower_L)
+            for (name, value) in (
+                ("stress_U_strut", stress_U_strut),
+                ("SF_ult_U_strut", SF_ult_U_strut),
+                ("SF_buck_U_strut", SF_buck_U_strut),
+                ("stress_L_strut", stress_L_strut),
+                ("SF_ult_L_strut", SF_ult_L_strut),
+                ("SF_buck_L_strut", SF_buck_L_strut),
+            )
+                if !isnothing(value)
+                    HDF5.write(file, name, value)
+                end
+            end
             annotate_output_data_channels!(file)
         end
 

--- a/src/io/windio.jl
+++ b/src/io/windio.jl
@@ -125,7 +125,16 @@ function runOWENSWINDIO(modelopt, windio, path)
     assembly,
     sections,
     AD15bldNdIdxRng,
-    AD15bldElIdxRng = OWENS.setupOWENS(path; setup_options = setup_opts)
+    AD15bldElIdxRng,
+    custom_mesh_outputs,
+    stiff_array,
+    mass_array,
+    strut_precompinput,
+    strut_precompoutput,
+    plyprops_strut,
+    numadIn_strut,
+    lam_U_strut,
+    lam_L_strut = OWENS.setupOWENS(path; setup_options = setup_opts)
 
     # Apply boundary conditions
     pBC = [
@@ -256,7 +265,15 @@ function runOWENSWINDIO(modelopt, windio, path)
     topDamage_blade_U,
     topDamage_blade_L,
     topDamage_tower_U,
-    topDamage_tower_L = OWENS.extractSF(
+    topDamage_tower_L,
+    topDamage_strut_U,
+    topDamage_strut_L,
+    stress_U_strut,
+    SF_ult_U_strut,
+    SF_buck_U_strut,
+    stress_L_strut,
+    SF_ult_L_strut,
+    SF_buck_L_strut = OWENS.extractSF(
         bld_precompinput,
         bld_precompoutput,
         plyprops_bld,
@@ -285,7 +302,12 @@ function runOWENSWINDIO(modelopt, windio, path)
         delta_t = modelopt.OWENS_Options.delta_t,
         AD15bldNdIdxRng,
         AD15bldElIdxRng,
-        strut_precompoutput = nothing,
+        strut_precompoutput,
+        strut_precompinput,
+        plyprops_strut,
+        numadIn_strut,
+        lam_U_strut,
+        lam_L_strut,
     )
 
     # Output data
@@ -333,6 +355,12 @@ function runOWENSWINDIO(modelopt, windio, path)
         topDamage_blade_L,
         topDamage_tower_U,
         topDamage_tower_L,
+        stress_U_strut,
+        SF_ult_U_strut,
+        SF_buck_U_strut,
+        stress_L_strut,
+        SF_ult_L_strut,
+        SF_buck_L_strut,
     )
 end
 

--- a/src/postprocess/PostProcessing.jl
+++ b/src/postprocess/PostProcessing.jl
@@ -642,6 +642,13 @@ function fatigue_damage(
     wohler_exp = 3,
     equiv_cycles = 1,
 )
+    if !all(isfinite, stress) ||
+       !all(isfinite, sn_stress) ||
+       !all(isfinite, sn_log_cycles) ||
+       !isfinite(ultimate_strength)
+        return NaN
+    end
+
     # default values
     isnothing(nbins_mean) && (nbins_mean = (mean_correction ? 10 : 1))
 
@@ -871,6 +878,121 @@ function printsf_twr(
     end
 end
 
+_has_strut_postprocess_data(value) =
+    !isnothing(value) && !(value isa AbstractVector && isempty(value))
+
+function _first_strut_dataset(value::AbstractVector)
+    isempty(value) && return value
+    first_value = first(value)
+    return first_value isa AbstractVector ? first_value : value
+end
+_first_strut_dataset(value) = value
+
+function _first_strut_laminate(value::AbstractVector)
+    isempty(value) && return value
+    first_value = first(value)
+    return first_value isa AbstractArray ? first_value : value
+end
+_first_strut_laminate(value) = value
+
+function _first_strut_object(value::AbstractVector)
+    isempty(value) && return value
+    return first(value)
+end
+_first_strut_object(value) = value
+
+function _interpolate_strut_strain_histories(
+    mymesh,
+    AD15bldNdIdxRng,
+    AD15bldElIdxRng,
+    Nbld,
+    N_ts,
+    strut_precompinput,
+    numadIn_strut,
+    epsilon_x_hist,
+    meanepsilon_z_hist,
+    meanepsilon_y_hist,
+    kappa_x_hist,
+    kappa_y_hist,
+    kappa_z_hist,
+)
+    strut_body_indices = (Nbld+1):size(AD15bldNdIdxRng, 1)
+    n_strut_bodies = length(strut_body_indices)
+    strut_len = length(strut_precompinput)
+
+    eps_x_strut = zeros(eltype(epsilon_x_hist), n_strut_bodies, N_ts, strut_len)
+    eps_z_strut = zeros(eltype(meanepsilon_z_hist), n_strut_bodies, N_ts, strut_len)
+    eps_y_strut = zeros(eltype(meanepsilon_y_hist), n_strut_bodies, N_ts, strut_len)
+    kappa_x_strut = zeros(eltype(kappa_x_hist), n_strut_bodies, N_ts, strut_len)
+    kappa_y_strut = zeros(eltype(kappa_y_hist), n_strut_bodies, N_ts, strut_len)
+    kappa_z_strut = zeros(eltype(kappa_z_hist), n_strut_bodies, N_ts, strut_len)
+
+    for (istrut, ibld) in enumerate(strut_body_indices)
+        startN = Int(AD15bldNdIdxRng[ibld, 1])
+        stopN = Int(AD15bldNdIdxRng[ibld, 2])
+        if stopN < startN
+            startN, stopN = stopN, startN
+        end
+
+        startE = Int(AD15bldElIdxRng[ibld, 1])
+        stopE = Int(AD15bldElIdxRng[ibld, 2])
+        if stopE < startE
+            startE, stopE = stopE, startE
+        end
+
+        mesh_span_strut = abs.(mymesh.z[startN:stopN] .- mymesh.z[startN])
+        mesh_span_strut_el = safeakima(
+            LinRange(0, 1, length(mesh_span_strut)),
+            mesh_span_strut,
+            LinRange(0, 1, stopE-startE+1),
+        )
+        composites_span_strut =
+            numadIn_strut.span/maximum(numadIn_strut.span)*maximum(mesh_span_strut_el)
+
+        for its = 1:N_ts
+            eps_x_strut[istrut, its, :] = safeakima(
+                mesh_span_strut_el,
+                epsilon_x_hist[1, startE:stopE, its],
+                composites_span_strut,
+            )
+            eps_z_strut[istrut, its, :] = safeakima(
+                mesh_span_strut_el,
+                meanepsilon_z_hist[1, startE:stopE, its],
+                composites_span_strut,
+            )
+            eps_y_strut[istrut, its, :] = safeakima(
+                mesh_span_strut_el,
+                meanepsilon_y_hist[1, startE:stopE, its],
+                composites_span_strut,
+            )
+            kappa_x_strut[istrut, its, :] = safeakima(
+                mesh_span_strut_el,
+                kappa_x_hist[1, startE:stopE, its],
+                composites_span_strut,
+            )
+            kappa_y_strut[istrut, its, :] = safeakima(
+                mesh_span_strut_el,
+                kappa_y_hist[1, startE:stopE, its],
+                composites_span_strut,
+            )
+            kappa_z_strut[istrut, its, :] = safeakima(
+                mesh_span_strut_el,
+                kappa_z_hist[1, startE:stopE, its],
+                composites_span_strut,
+            )
+        end
+    end
+
+    return (
+        eps_x = eps_x_strut,
+        eps_z = eps_z_strut,
+        eps_y = eps_y_strut,
+        kappa_x = kappa_x_strut,
+        kappa_y = kappa_y_strut,
+        kappa_z = kappa_z_strut,
+    )
+end
+
 function extractSF(
     bld_precompinput,
     bld_precompoutput,
@@ -1052,80 +1174,44 @@ function extractSF(
         end
     end
 
-    if !isnothing(strut_precompoutput)
+    strut_data_available = _has_strut_postprocess_data(strut_precompoutput)
+    if strut_data_available
+        strut_precompoutput = _first_strut_dataset(strut_precompoutput)
+        strut_precompinput = _first_strut_dataset(strut_precompinput)
+        plyprops_strut = _first_strut_object(plyprops_strut)
+        numadIn_strut = _first_strut_object(numadIn_strut)
+        lam_U_strut = _first_strut_laminate(lam_U_strut)
+        lam_L_strut = _first_strut_laminate(lam_L_strut)
+
         ####################################################
         #### Get strain values at the struts ########
         ####################################################
 
-        eps_x_strut = zeros(Nbld*2, N_ts, length(strut_precompinput))
-        eps_z_strut = zeros(Nbld*2, N_ts, length(strut_precompinput))
-        eps_y_strut = zeros(Nbld*2, N_ts, length(strut_precompinput))
-        kappa_x_strut = zeros(Nbld*2, N_ts, length(strut_precompinput))
-        kappa_y_strut = zeros(Nbld*2, N_ts, length(strut_precompinput))
-        kappa_z_strut = zeros(Nbld*2, N_ts, length(strut_precompinput))
+        strut_histories = _interpolate_strut_strain_histories(
+            mymesh,
+            AD15bldNdIdxRng,
+            AD15bldElIdxRng,
+            Nbld,
+            N_ts,
+            strut_precompinput,
+            numadIn_strut,
+            epsilon_x_hist,
+            meanepsilon_z_hist,
+            meanepsilon_y_hist,
+            kappa_x_hist,
+            kappa_y_hist,
+            kappa_z_hist,
+        )
+        eps_x_strut = strut_histories.eps_x
+        eps_z_strut = strut_histories.eps_z
+        eps_y_strut = strut_histories.eps_y
+        kappa_x_strut = strut_histories.kappa_x
+        kappa_y_strut = strut_histories.kappa_y
+        kappa_z_strut = strut_histories.kappa_z
 
-        istrut = 0
-        for ibld = (Nbld+1):length(AD15bldNdIdxRng[:, 1])
-            istrut += 1
-
-            startN = Int(AD15bldNdIdxRng[ibld, 1])
-            stopN = Int(AD15bldNdIdxRng[ibld, 2])
-            if stopN < startN
-                temp = stopN
-                stopN = startN
-                startN = temp
-            end
-
-            startE = Int(AD15bldElIdxRng[ibld, 1])
-            stopE = Int(AD15bldElIdxRng[ibld, 2])
-            if stopE < startE
-                temp = stopE
-                stopE = startE
-                startE = temp
-            end
-
-            mesh_span_strut = abs.(mymesh.z[startN:stopN] .- mymesh.z[startN])
-            mesh_span_strut_el = safeakima(
-                LinRange(0, 1, length(mesh_span_strut)),
-                mesh_span_strut,
-                LinRange(0, 1, stopE-startE+1),
-            )
-            composites_span_strut =
-                numadIn_strut.span/maximum(numadIn_strut.span)*maximum(mesh_span_strut_el) #TODO: this assumes struts and blades are straight, should be mapped for all potential cases, also need to input hub offset
-
-            for its = 1:N_ts
-                # Interpolate to the composite inputs #TODO: verify node vs el in strain
-                eps_x_strut[istrut, its, :] = safeakima(
-                    mesh_span_strut_el,
-                    epsilon_x_hist[1, startE:stopE, its],
-                    composites_span_strut,
-                )
-                eps_z_strut[istrut, its, :] = safeakima(
-                    mesh_span_strut_el,
-                    meanepsilon_z_hist[1, startE:stopE, its],
-                    composites_span_strut,
-                )
-                eps_y_strut[istrut, its, :] = safeakima(
-                    mesh_span_strut_el,
-                    meanepsilon_y_hist[1, startE:stopE, its],
-                    composites_span_strut,
-                )
-                kappa_x_strut[istrut, its, :] = safeakima(
-                    mesh_span_strut_el,
-                    kappa_x_hist[1, startE:stopE, its],
-                    composites_span_strut,
-                )
-                kappa_y_strut[istrut, its, :] = safeakima(
-                    mesh_span_strut_el,
-                    kappa_y_hist[1, startE:stopE, its],
-                    composites_span_strut,
-                )
-                kappa_z_strut[istrut, its, :] = safeakima(
-                    mesh_span_strut_el,
-                    kappa_z_hist[1, startE:stopE, its],
-                    composites_span_strut,
-                )
-            end
+        if size(eps_x_strut, 1) == 0
+            @warn "Strut PreComp data was provided, but no strut element ranges were found. Skipping strut safety factor post-processing."
+            strut_data_available = false
         end
     end
 
@@ -1280,116 +1366,157 @@ function extractSF(
         useStation = usestationBld,
     )
 
-    if !isnothing(strut_precompoutput)
+    if strut_data_available
         ##########################################
         #### Calculate Stress At the Struts
         ##########################################
 
-        stress_U_strut =
-            zeros(N_ts, length(strut_precompinput), length(lam_U_strut[1, :]), 3)
-        SF_ult_U_strut = zeros(N_ts, length(strut_precompinput), length(lam_U_strut[1, :]))
-        SF_buck_U_strut = zeros(N_ts, length(strut_precompinput), length(lam_U_strut[1, :]))
-
-        topstrainout_strut_U, topDamage_strut_U = calcSF(
-            total_t,
-            stress_U_strut,
-            SF_ult_U_strut,
-            SF_buck_U_strut,
+        n_strut_bodies = size(eps_x_strut, 1)
+        stress_U_strut = zeros(
+            NT,
+            n_strut_bodies,
+            N_ts,
             length(strut_precompinput),
-            plyprops_strut,
-            strut_precompinput,
-            strut_precompoutput,
-            lam_U_strut,
-            eps_x_strut[1, :, :],
-            eps_z_strut[1, :, :],
-            eps_y_strut[1, :, :],
-            kappa_x_strut[1, :, :],
-            kappa_y_strut[1, :, :],
-            kappa_z_strut[1, :, :],
-            numadIn_strut;
-            failmethod = "maxstress",
-            upper = true,
-            calculate_fatigue,
+            length(lam_U_strut[1, :]),
+            3,
         )
-
-        if verbosity>0
-            println("Composite Ultimate and Buckling Safety Factors")
-            println("\n\nUPPER STRUT SURFACE")
-        end
-
-        if usestationStrut != 0
-            println(
-                "maximum strut stress: $(maximum(stress_U_strut[:,usestationStrut,8,1]))",
-            )
-            println(
-                "minimum strut stress: $(minimum(stress_U_strut[:,usestationStrut,8,1]))",
-            )
-        end
-        printSF(
-            verbosity,
-            SF_ult_U_strut,
-            SF_buck_U_strut,
-            composite_station_idx_U_strut,
-            composite_station_name_U_strut,
+        SF_ult_U_strut = zeros(
+            NT,
+            n_strut_bodies,
+            N_ts,
             length(strut_precompinput),
-            lam_U_strut,
-            topDamage_strut_U,
-            delta_t,
-            total_t;
-            useStation = usestationStrut,
+            size(lam_U_strut, 2),
         )
-
-        stress_L_strut =
-            zeros(NT, N_ts, length(strut_precompinput), size(lam_U_strut, 2), 3)
-        SF_ult_L_strut = zeros(NT, N_ts, length(strut_precompinput), size(lam_L_strut, 2))
-        SF_buck_L_strut = zeros(NT, N_ts, length(strut_precompinput), size(lam_L_strut, 2))
-
-        topstrainout_strut_L, topDamage_strut_L = calcSF(
-            total_t,
-            stress_L_strut,
-            SF_ult_L_strut,
-            SF_buck_L_strut,
+        SF_buck_U_strut = zeros(
+            NT,
+            n_strut_bodies,
+            N_ts,
             length(strut_precompinput),
-            plyprops_strut,
-            strut_precompinput,
-            strut_precompoutput,
-            lam_L_strut,
-            eps_x_strut[1, :, :],
-            eps_z_strut[1, :, :],
-            eps_y_strut[1, :, :],
-            kappa_x_strut[1, :, :],
-            kappa_y_strut[1, :, :],
-            kappa_z_strut[1, :, :],
-            numadIn_strut;
-            failmethod = "maxstress",
-            upper = false,
-            calculate_fatigue,
+            size(lam_U_strut, 2),
         )
+        topDamage_strut_U = Vector{Any}(undef, n_strut_bodies)
 
-        if verbosity>0
-            println("\n\nLOWER STRUT SURFACE")
-        end
-        if usestationStrut != 0
-            println(
-                "maximum strut stress: $(maximum(stress_L_strut[:,usestationStrut,8,1]))",
-            )
-            println(
-                "minimum strut stress: $(minimum(stress_L_strut[:,usestationStrut,8,1]))",
-            )
-        end
-        printSF(
-            verbosity,
-            SF_ult_L_strut,
-            SF_buck_L_strut,
-            composite_station_idx_L_strut,
-            composite_station_name_L_strut,
+        stress_L_strut = zeros(
+            NT,
+            n_strut_bodies,
+            N_ts,
             length(strut_precompinput),
-            lam_L_strut,
-            topDamage_strut_L,
-            delta_t,
-            total_t;
-            useStation = usestationStrut,
+            size(lam_L_strut, 2),
+            3,
         )
+        SF_ult_L_strut = zeros(
+            NT,
+            n_strut_bodies,
+            N_ts,
+            length(strut_precompinput),
+            size(lam_L_strut, 2),
+        )
+        SF_buck_L_strut = zeros(
+            NT,
+            n_strut_bodies,
+            N_ts,
+            length(strut_precompinput),
+            size(lam_L_strut, 2),
+        )
+        topDamage_strut_L = Vector{Any}(undef, n_strut_bodies)
+
+        for istrut = 1:n_strut_bodies
+            _, topDamage_strut_U[istrut] = calcSF(
+                total_t,
+                @view(stress_U_strut[istrut, :, :, :, :]),
+                @view(SF_ult_U_strut[istrut, :, :, :]),
+                @view(SF_buck_U_strut[istrut, :, :, :]),
+                length(strut_precompinput),
+                plyprops_strut,
+                strut_precompinput,
+                strut_precompoutput,
+                lam_U_strut,
+                eps_x_strut[istrut, :, :],
+                eps_z_strut[istrut, :, :],
+                eps_y_strut[istrut, :, :],
+                kappa_x_strut[istrut, :, :],
+                kappa_y_strut[istrut, :, :],
+                kappa_z_strut[istrut, :, :],
+                numadIn_strut;
+                failmethod = "maxstress",
+                upper = true,
+                calculate_fatigue,
+            )
+
+            if verbosity>0
+                println("Composite Ultimate and Buckling Safety Factors")
+                println("\n\nUPPER STRUT SURFACE $istrut")
+            end
+
+            if usestationStrut != 0
+                println(
+                    "maximum strut stress: $(maximum(stress_U_strut[istrut,:,usestationStrut,8,1]))",
+                )
+                println(
+                    "minimum strut stress: $(minimum(stress_U_strut[istrut,:,usestationStrut,8,1]))",
+                )
+            end
+            printSF(
+                verbosity,
+                @view(SF_ult_U_strut[istrut, :, :, :]),
+                @view(SF_buck_U_strut[istrut, :, :, :]),
+                composite_station_idx_U_strut,
+                composite_station_name_U_strut,
+                length(strut_precompinput),
+                lam_U_strut,
+                topDamage_strut_U[istrut],
+                delta_t,
+                total_t;
+                useStation = usestationStrut,
+            )
+
+            _, topDamage_strut_L[istrut] = calcSF(
+                total_t,
+                @view(stress_L_strut[istrut, :, :, :, :]),
+                @view(SF_ult_L_strut[istrut, :, :, :]),
+                @view(SF_buck_L_strut[istrut, :, :, :]),
+                length(strut_precompinput),
+                plyprops_strut,
+                strut_precompinput,
+                strut_precompoutput,
+                lam_L_strut,
+                eps_x_strut[istrut, :, :],
+                eps_z_strut[istrut, :, :],
+                eps_y_strut[istrut, :, :],
+                kappa_x_strut[istrut, :, :],
+                kappa_y_strut[istrut, :, :],
+                kappa_z_strut[istrut, :, :],
+                numadIn_strut;
+                failmethod = "maxstress",
+                upper = false,
+                calculate_fatigue,
+            )
+
+            if verbosity>0
+                println("\n\nLOWER STRUT SURFACE $istrut")
+            end
+            if usestationStrut != 0
+                println(
+                    "maximum strut stress: $(maximum(stress_L_strut[istrut,:,usestationStrut,8,1]))",
+                )
+                println(
+                    "minimum strut stress: $(minimum(stress_L_strut[istrut,:,usestationStrut,8,1]))",
+                )
+            end
+            printSF(
+                verbosity,
+                @view(SF_ult_L_strut[istrut, :, :, :]),
+                @view(SF_buck_L_strut[istrut, :, :, :]),
+                composite_station_idx_L_strut,
+                composite_station_name_L_strut,
+                length(strut_precompinput),
+                lam_L_strut,
+                topDamage_strut_L[istrut],
+                delta_t,
+                total_t;
+                useStation = usestationStrut,
+            )
+        end
     else
         topDamage_strut_U = nothing
         topDamage_strut_L = nothing

--- a/src/preprocessing/SetupTurbine.jl
+++ b/src/preprocessing/SetupTurbine.jl
@@ -375,6 +375,13 @@ function setupOWENS(
         lam_U_bld = []
         lam_L_bld = []
         mass_breakout_blds = []
+        strut_precompinput = []
+        strut_precompoutput = []
+        plyprops_strut = []
+        numadIn_strut = []
+        lam_U_strut = []
+        lam_L_strut = []
+        seen_strut_numbers = Set{String}()
 
         for component in components
             if contains(component.name, "tower")
@@ -399,6 +406,17 @@ function setupOWENS(
                 lam_U_bld = component.lam_U
                 lam_L_bld = component.lam_L
                 mass_breakout_blds = component.mass
+            end
+
+            strut_match = match(r"_strut(\d+)$", String(component.name))
+            if !isnothing(strut_match) && !(strut_match.captures[1] in seen_strut_numbers)
+                push!(seen_strut_numbers, strut_match.captures[1])
+                push!(strut_precompinput, component.preCompInput)
+                push!(strut_precompoutput, component.preCompOutput)
+                push!(plyprops_strut, component.plyProps)
+                push!(numadIn_strut, component.nuMadIn)
+                push!(lam_U_strut, component.lam_U)
+                push!(lam_L_strut, component.lam_L)
             end
         end
 
@@ -436,7 +454,13 @@ function setupOWENS(
             AD15bldElIdxRng,
             custom_mesh_outputs,
             stiff_array,
-            mass_array
+            mass_array,
+            strut_precompinput,
+            strut_precompoutput,
+            plyprops_strut,
+            numadIn_strut,
+            lam_U_strut,
+            lam_L_strut
         else
             return mymesh,
             myel,
@@ -470,7 +494,13 @@ function setupOWENS(
             AD15bldElIdxRng,
             custom_mesh_outputs,
             stiff_array,
-            mass_array
+            mass_array,
+            strut_precompinput,
+            strut_precompoutput,
+            plyprops_strut,
+            numadIn_strut,
+            lam_U_strut,
+            lam_L_strut
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,10 @@ end
     include("$path/test_validation_reports.jl")
 end
 
+@testset "Strut Postprocessing" begin
+    include("$path/test_postprocess_struts.jl")
+end
+
 @testset "Aero Mapping" begin
     include("$path/test_aero_mapping.jl")
 end

--- a/test/test_postprocess_struts.jl
+++ b/test/test_postprocess_struts.jl
@@ -1,0 +1,81 @@
+using Test
+import OWENS
+
+@testset "Strut strain histories use actual strut ranges" begin
+    Nbld = 2
+    nstrut_per_blade = 3
+    n_strut_bodies = Nbld * nstrut_per_blade
+    n_bodies = Nbld + n_strut_bodies
+    nodes_per_body = 4
+    elems_per_body = nodes_per_body - 1
+    N_ts = 2
+
+    z = Float64[]
+    AD15bldNdIdxRng = zeros(Int, n_bodies, 2)
+    AD15bldElIdxRng = zeros(Int, n_bodies, 2)
+    for ibody = 1:n_bodies
+        start_node = length(z) + 1
+        append!(z, (0.0:(nodes_per_body-1)) .+ 10.0 * ibody)
+        stop_node = length(z)
+        start_el = (ibody - 1) * elems_per_body + 1
+        stop_el = ibody * elems_per_body
+        AD15bldNdIdxRng[ibody, :] = [start_node, stop_node]
+        AD15bldElIdxRng[ibody, :] = [start_el, stop_el]
+    end
+
+    total_elems = n_bodies * elems_per_body
+    epsilon_x_hist = zeros(4, total_elems, N_ts)
+    for iel = 1:total_elems, its = 1:N_ts
+        epsilon_x_hist[1, iel, its] = 100iel + its
+    end
+
+    meanepsilon_z_hist = epsilon_x_hist[1:1, :, :] .+ 1.0
+    meanepsilon_y_hist = epsilon_x_hist[1:1, :, :] .+ 2.0
+    kappa_x_hist = epsilon_x_hist .+ 3.0
+    kappa_y_hist = epsilon_x_hist .+ 4.0
+    kappa_z_hist = epsilon_x_hist .+ 5.0
+
+    mymesh = (; z)
+    strut_precompinput = [nothing, nothing, nothing]
+    numadIn_strut = (; span = [0.0, 0.5, 1.0])
+
+    histories = OWENS._interpolate_strut_strain_histories(
+        mymesh,
+        AD15bldNdIdxRng,
+        AD15bldElIdxRng,
+        Nbld,
+        N_ts,
+        strut_precompinput,
+        numadIn_strut,
+        epsilon_x_hist,
+        meanepsilon_z_hist,
+        meanepsilon_y_hist,
+        kappa_x_hist,
+        kappa_y_hist,
+        kappa_z_hist,
+    )
+
+    @test size(histories.eps_x) == (n_strut_bodies, N_ts, length(strut_precompinput))
+
+    first_strut_row = Nbld + 1
+    first_strut_start_el = AD15bldElIdxRng[first_strut_row, 1]
+    first_strut_stop_el = AD15bldElIdxRng[first_strut_row, 2]
+    @test histories.eps_x[1, 1, :] ≈ epsilon_x_hist[
+        1,
+        first_strut_start_el:first_strut_stop_el,
+        1,
+    ]
+
+    last_strut_row = size(AD15bldElIdxRng, 1)
+    last_strut_start_el = AD15bldElIdxRng[last_strut_row, 1]
+    last_strut_stop_el = AD15bldElIdxRng[last_strut_row, 2]
+    @test histories.kappa_z[end, 2, :] ≈ kappa_z_hist[
+        1,
+        last_strut_start_el:last_strut_stop_el,
+        2,
+    ]
+end
+
+@testset "Non-finite fatigue input returns invalid damage" begin
+    @test isnan(OWENS.fatigue_damage([NaN, 1.0], [1.0, 2.0], [3.0, 4.0], 100.0))
+end


### PR DESCRIPTION
## Summary
- expose strut PreComp and laminate data from setupOWENS legacy returns
- enable strut safety-factor post-processing in WindIO and example scripts instead of forcing strut_precompoutput to nothing
- interpolate all AD15 strut body ranges and write optional strut stress/safety-factor datasets
- document the URL-dependency fallback for OWENSOpenFASTWrappers resolution failures

Fixes #48.
Refs #93.

## Tests
- julia --project=. --startup-file=no -e 'include("test/test_postprocess_struts.jl")'
- julia --project=. --startup-file=no -e 'include("test/test_output_data_channels.jl")'
- julia --startup-file=no -e 'for file in ARGS; expr = Meta.parseall(read(file, String)); if expr isa Expr && expr.head == :error; error("parse error in : "); end; end; println("parse ok")' examples/SNL34m/SNL34mVAWTNormalOperation.jl examples/SNL34m/Example34mHVAWTConfiguration.jl examples/helical_riverine/helical_riverine_driver.jl examples/literate/E_RM2_Medium.jl examples/literate/C_customizablePreprocessing.jl src/io/windio.jl src/postprocess/PostProcessing.jl src/preprocessing/SetupTurbine.jl
- JULIA_DEPOT_PATH=<temp> julia --startup-file=no -e 'using Pkg; Pkg.add(Pkg.PackageSpec(url="https://github.com/sandialabs/OWENS.jl.git"))' (expected current failure: OWENSOpenFASTWrappers has no known versions)